### PR TITLE
docs: start sync v2 architecture track

### DIFF
--- a/docs/adr/002-sync-v2-multi-device-crdt.md
+++ b/docs/adr/002-sync-v2-multi-device-crdt.md
@@ -1,0 +1,167 @@
+# ADR-002: Sync v2 — Multi-device, periodic sync, and advanced conflict resolution
+
+## Status
+
+Proposed
+
+## Context
+
+The current sync implementation is useful as a first production step, but it is still fundamentally:
+
+- peer-to-peer between two peers at a time
+- snapshot-based
+- merge-by-entity using `updatedAt` (LWW)
+- oriented to an explicit "share / receive" interaction
+
+That solves an important MVP, but it falls short for the product experience we actually want:
+
+1. **Single action: sync** instead of "send" vs "receive"
+2. **Multi-user / multi-device** behavior
+3. **Periodic retry / background sync attempts**
+4. **Advanced conflict resolution** beyond timestamp-only merge
+5. **Clear path to eventual real-time collaboration**
+
+## Decision
+
+We will treat the current PR #100 as **Sync v1** and open a new line of work for **Sync v2** with these product and architecture goals.
+
+### Product goals for Sync v2
+
+- The user should see a single primary action: **Sincronitzar**
+- Any peer with the group key should be able to join the sync mesh
+- Sync should support **repeated attempts over time** instead of one-shot transfers only
+- The system should merge concurrent edits more safely than plain LWW snapshots
+- The UX should expose:
+  - last successful sync
+  - peers seen recently
+  - sync status / retry state
+  - unresolved conflicts when automation is insufficient
+
+### Architecture goals for Sync v2
+
+#### 1. Session model: mesh-ready, not 1:1
+
+Replace the current single-remote-peer session model with a topology that can coordinate:
+
+- 1 user with multiple devices
+- multiple participants of the same group
+- repeated sync rounds with more than one remote peer
+
+Implications:
+- `SyncSessionStatus` should track **many remote peers**, not just one `remotePeerId`
+- orchestration should support **fan-out** and **incremental reconciliation**
+- connection lifecycle should tolerate peers appearing/disappearing
+
+#### 2. Sync mode: periodic reconciliation
+
+Sync v2 should support retries and periodic attempts:
+
+- manual sync trigger from UI
+- auto-retry while the sync screen is open
+- optional periodic background attempts on app resume / visibility change
+- eventual cron/background strategies only if platform support exists later
+
+The important shift is: sync is not a single transfer, but an ongoing reconciliation process.
+
+#### 3. Conflict model: move toward operation-based or CRDT-backed sync
+
+Current v1 uses snapshot exchange + LWW merge. For v2, the target direction is:
+
+- **CRDT or CRDT-like replicated state** for the collaborative parts of a group
+- deterministic merge without relying only on wall-clock timestamps
+- explicit causal metadata or lamport/vector-style ordering where needed
+
+Practical recommendation:
+- evaluate **Yjs** as the primary candidate for shared replicated state
+- keep app-level encryption above transport
+- map Reparteix domain entities into a replicated document model
+
+Why Yjs first:
+- mature ecosystem
+- good browser support
+- proven multi-peer sync patterns
+- better fit for incremental synchronization than repeated full snapshots
+
+### Recommended Sync v2 layering
+
+```
+UI / Store
+  -> Sync coordinator
+  -> Replicated document model (Yjs candidate)
+  -> App-level encryption
+  -> WebRTC mesh transport
+  -> Optional relay / signaling / async bridge
+```
+
+### Additional ideas worth including in v2
+
+Beyond the points already requested, these are also worth adding:
+
+1. **Per-group device identity**
+   - know which device last synced
+   - avoid ambiguous "someone changed something"
+
+2. **Sync journal / diagnostics**
+   - last sync time
+   - peers reached
+   - bytes exchanged
+   - last failure reason
+
+3. **Explicit conflict UI for hard cases**
+   - most merges should be automatic
+   - but impossible/ambiguous merges need a human-visible resolution path
+
+4. **Optional async relay later**
+   - pure P2P is great, but not enough when peers are never online together
+   - future optional encrypted relay could improve reliability without giving up privacy
+
+5. **Key rotation / membership changes**
+   - if a participant leaves a group, key management becomes important
+   - v2 should at least leave space for future re-keying
+
+## Consequences
+
+### Positive
+
+- Aligns the product with the real user mental model: "sync my group"
+- Opens the door to multi-device and multi-user reliability
+- Reduces data-loss/conflict risk from timestamp-only merges
+- Creates a clean architectural boundary between v1 and the more advanced model
+
+### Negative / Risks
+
+- Considerably more complexity than snapshot sync
+- CRDT integration will affect store, persistence and protocol design
+- Background sync in browsers is constrained by platform limitations
+- Encryption over replicated docs needs careful design to avoid leaking metadata unnecessarily
+
+## Implementation strategy
+
+Sync v2 should land incrementally, not as a full rewrite in one go:
+
+### Phase 1
+- New session model with multi-peer awareness
+- UI change from "Compartir/Rebre" to **"Sincronitzar"**
+- periodic retry loop while sync is active
+- sync diagnostics
+
+### Phase 2
+- Introduce replicated document abstraction
+- prototype Yjs-backed group model
+- validate encrypted multi-peer merge behavior
+
+### Phase 3
+- migrate from snapshot-first sync to incremental sync
+- add conflict UI for non-trivial cases
+- define optional async relay strategy
+
+## Decision boundary
+
+- **PR #100 remains Sync v1**
+- **Sync v2 starts as a separate PR/track**, because the conceptual model changes enough that mixing both in one PR would create noise and accidental regressions
+
+## References
+
+- ADR-001: `docs/adr/001-sync-architecture.md`
+- PR #100: current Sync v1 implementation line
+- Candidate technology: Yjs

--- a/docs/sync-v2-plan.md
+++ b/docs/sync-v2-plan.md
@@ -100,16 +100,18 @@ Goal: make the system operationally useful in real life.
 ### Runtime / coordinator
 
 - [x] `SyncSessionStatus` supports many peers
+- [x] primary entry point auto-creates or auto-joins a sync session
 - [ ] sync coordinator distinguishes discovery, sync round, retry backoff and idle states
 - [ ] periodic retry loop with visibility-aware throttling
 - [ ] sync journal persisted per group
 
 ### UI / product
 
-- [ ] replace send/receive with unified sync CTA
-- [ ] add "last synced" and "last error" indicators
-- [ ] add peer list / presence summary
+- [x] replace send/receive with unified sync CTA
+- [ ] add explicit "last synced" and "last error" indicators
+- [x] add peer list / presence summary
 - [ ] add conflict banner or resolution entry point
+- [x] expose basic runtime diagnostics (`lastAttemptAt`, `lastSuccessAt`)
 
 ### Data model
 

--- a/docs/sync-v2-plan.md
+++ b/docs/sync-v2-plan.md
@@ -1,0 +1,142 @@
+# Sync v2 Plan
+
+This document turns ADR-002 into an implementation plan with concrete acceptance criteria.
+
+## Product outcome
+
+The end state for Sync v2 is:
+
+- the user sees a single action: **Sincronitzar**
+- the same group can sync across **multiple users and multiple devices**
+- synchronization can be retried periodically, not only as a one-shot transfer
+- conflicts are resolved more safely than plain `updatedAt`-only LWW
+- the UI explains sync status instead of hiding it
+
+## Non-goals for the first v2 increment
+
+These should not block the first usable v2 milestone:
+
+- full Google Docs style real-time collaboration
+- perfect background sync on all browsers
+- member revocation / key rotation fully solved
+- async relay infrastructure in the first milestone
+
+## Acceptance criteria by phase
+
+### Phase 1, UX and orchestration
+
+Goal: move from "share/receive" to "sync" and prepare the runtime for repeated reconciliation.
+
+#### Scope
+
+- replace explicit **Compartir / Rebre** branching with a single **Sincronitzar** flow
+- make session state multi-peer aware
+- add retry loop while sync is active
+- expose sync diagnostics in UI
+
+#### Acceptance criteria
+
+- user can open sync for a group and press a single main action
+- session status can represent more than one remote peer
+- sync retries happen automatically while the sync surface is open
+- UI shows:
+  - last successful sync time
+  - current peers seen / connected
+  - last failure reason
+- existing Sync v1 behavior does not regress for the simple two-peer case
+
+#### Suggested implementation slices
+
+1. `SyncSessionStatus`
+   - replace `remotePeerId: string | null` with a peer collection
+2. sync coordinator
+   - separate discovery / connection / reconciliation lifecycle
+3. UI
+   - replace send/receive buttons with one sync action
+   - add sync status panel
+
+### Phase 2, replicated state prototype
+
+Goal: validate a CRDT-backed model for Reparteix group data.
+
+#### Scope
+
+- prototype Yjs-backed group document
+- map group, members, expenses and payments into replicated structures
+- validate encrypted payload exchange over current transport
+
+#### Acceptance criteria
+
+- two peers can exchange incremental updates without sending a full snapshot every time
+- concurrent edits made on both sides converge deterministically
+- same-device refresh preserves replicated state through persistence
+- encryption boundary is still above transport
+
+#### Open design questions
+
+- one Y.Doc per group vs split docs by entity type
+- how to persist CRDT state in IndexedDB cleanly
+- whether app-level encryption wraps update batches or a higher-level envelope
+
+### Phase 3, conflict handling and reliability
+
+Goal: make the system operationally useful in real life.
+
+#### Scope
+
+- add conflict visibility for hard cases
+- improve retry and peer availability heuristics
+- prepare optional async relay path
+
+#### Acceptance criteria
+
+- users can see unresolved conflicts when automation is insufficient
+- the app can retry sync without user micromanagement
+- multi-device sync is stable enough for normal repeated usage
+- architecture leaves room for optional encrypted relay without rewriting the domain model
+
+## Suggested technical backlog
+
+### Runtime / coordinator
+
+- [ ] `SyncSessionStatus` supports many peers
+- [ ] sync coordinator distinguishes discovery, sync round, retry backoff and idle states
+- [ ] periodic retry loop with visibility-aware throttling
+- [ ] sync journal persisted per group
+
+### UI / product
+
+- [ ] replace send/receive with unified sync CTA
+- [ ] add "last synced" and "last error" indicators
+- [ ] add peer list / presence summary
+- [ ] add conflict banner or resolution entry point
+
+### Data model
+
+- [ ] identify which entities can stay LWW and which need CRDT semantics
+- [ ] prototype Yjs schema for group data
+- [ ] define persistence strategy for replicated document state
+- [ ] define migration path from snapshot sync to incremental sync
+
+### Security
+
+- [ ] define key ownership model for multi-device sync
+- [ ] define how new peers get authorized
+- [ ] leave extension points for future re-keying
+
+## Additional ideas worth evaluating
+
+These are not mandatory for the first milestone, but they are likely valuable:
+
+- device naming, so sync status can say "Edu iPhone" / "MacBook" instead of anonymous peers
+- change summaries after sync, for example "2 despeses noves, 1 pagament actualitzat"
+- explicit manual "force full resync" action for recovery
+- optional async encrypted relay for peers that are never online together
+
+## Delivery recommendation
+
+The safest path is:
+
+1. keep PR #100 as Sync v1
+2. use PR #104 for v2 artifacts and early implementation slices
+3. land Phase 1 first before committing the whole codebase to a CRDT migration

--- a/docs/sync-v2-plan.md
+++ b/docs/sync-v2-plan.md
@@ -99,7 +99,7 @@ Goal: make the system operationally useful in real life.
 
 ### Runtime / coordinator
 
-- [ ] `SyncSessionStatus` supports many peers
+- [x] `SyncSessionStatus` supports many peers
 - [ ] sync coordinator distinguishes discovery, sync round, retry backoff and idle states
 - [ ] periodic retry loop with visibility-aware throttling
 - [ ] sync journal persisted per group

--- a/docs/sync-v2-plan.md
+++ b/docs/sync-v2-plan.md
@@ -108,7 +108,7 @@ Goal: make the system operationally useful in real life.
 ### UI / product
 
 - [x] replace send/receive with unified sync CTA
-- [ ] add explicit "last synced" and "last error" indicators
+- [x] add explicit "last synced" and "last error" indicators
 - [x] add peer list / presence summary
 - [ ] add conflict banner or resolution entry point
 - [x] expose basic runtime diagnostics (`lastAttemptAt`, `lastSuccessAt`)

--- a/src/features/groups/SyncPanel.tsx
+++ b/src/features/groups/SyncPanel.tsx
@@ -124,6 +124,19 @@ function StateIcon({ state }: { state: string }) {
   }
 }
 
+function formatSyncTimestamp(value: string | null): string | null {
+  if (!value) return null
+
+  try {
+    return new Date(value).toLocaleString('ca-ES', {
+      dateStyle: 'short',
+      timeStyle: 'short',
+    })
+  } catch {
+    return value
+  }
+}
+
 function StateBadge({ state }: { state: string }) {
   const labels: Record<string, string> = {
     'idle': 'Preparat',
@@ -333,10 +346,18 @@ export function SyncPanel({ groupId }: SyncPanelProps) {
             {/* Status message */}
             <div className="space-y-1">
               <p className="text-sm">{sync.message}</p>
-              {sync.remotePeerIds.length > 0 && (
-                <p className="text-xs text-muted-foreground">
-                  Peers detectats: {sync.remotePeerIds.join(', ')}
-                </p>
+              {(sync.remotePeerIds.length > 0 || sync.lastAttemptAt || sync.lastSuccessAt) && (
+                <div className="space-y-1 text-xs text-muted-foreground">
+                  {sync.remotePeerIds.length > 0 && (
+                    <p>Peers detectats: {sync.remotePeerIds.join(', ')}</p>
+                  )}
+                  {sync.lastAttemptAt && (
+                    <p>Últim intent: {formatSyncTimestamp(sync.lastAttemptAt)}</p>
+                  )}
+                  {sync.lastSuccessAt && (
+                    <p>Última sync correcta: {formatSyncTimestamp(sync.lastSuccessAt)}</p>
+                  )}
+                </div>
               )}
             </div>
 

--- a/src/features/groups/SyncPanel.tsx
+++ b/src/features/groups/SyncPanel.tsx
@@ -179,6 +179,7 @@ export function SyncPanel({ groupId }: SyncPanelProps) {
   const sync = useSync({
     groupId,
     passphrase,
+    autoRetryEnabled: mode !== 'idle',
   })
 
   const isActive = sync.state !== 'idle' && sync.state !== 'error' && sync.state !== 'completed'
@@ -330,6 +331,9 @@ export function SyncPanel({ groupId }: SyncPanelProps) {
                   )}
                   {sync.lastSuccessAt && (
                     <p>Última sync correcta: {formatSyncTimestamp(sync.lastSuccessAt)}</p>
+                  )}
+                  {sync.autoRetryEnabled && (
+                    <p>Reintent automàtic actiu mentre aquest panell estigui obert</p>
                   )}
                 </div>
               )}

--- a/src/features/groups/SyncPanel.tsx
+++ b/src/features/groups/SyncPanel.tsx
@@ -201,20 +201,6 @@ export function SyncPanel({ groupId }: SyncPanelProps) {
     }
   }
 
-  const handleStart = async (selectedMode: 'host' | 'join') => {
-    setMode(selectedMode)
-    try {
-      await persistPassphrase(passphrase)
-      if (selectedMode === 'host') {
-        await sync.startAsHost()
-      } else {
-        await sync.joinSession()
-      }
-    } catch {
-      // Error is handled by the sync hook
-    }
-  }
-
   const handleReset = () => {
     sync.reset()
     setMode('idle')
@@ -290,35 +276,23 @@ export function SyncPanel({ groupId }: SyncPanelProps) {
           </p>
         </div>
 
-        {/* Phase 1 V2 UX: one primary sync action, with optional explicit receive path kept as secondary */}
         {sync.state === 'idle' && (
-          <div className="space-y-2">
-            <Button
-              onClick={async () => {
-                setMode('host')
-                try {
-                  await persistPassphrase(passphrase)
-                  await sync.startSync()
-                } catch {
-                  // Error is handled by the sync hook
-                }
-              }}
-              disabled={!canStart}
-              className="w-full"
-            >
-              <RefreshCw className="h-4 w-4 mr-2" />
-              Sincronitzar ara
-            </Button>
-            <Button
-              variant="outline"
-              onClick={() => handleStart('join')}
-              disabled={!canStart}
-              className="w-full"
-            >
-              <Wifi className="h-4 w-4 mr-2" />
-              Obrir en mode connexió manual
-            </Button>
-          </div>
+          <Button
+            onClick={async () => {
+              setMode('host')
+              try {
+                await persistPassphrase(passphrase)
+                await sync.startSync()
+              } catch {
+                // Error is handled by the sync hook
+              }
+            }}
+            disabled={!canStart}
+            className="w-full"
+          >
+            <RefreshCw className="h-4 w-4 mr-2" />
+            Sincronitzar
+          </Button>
         )}
 
         {/* Active sync status */}

--- a/src/features/groups/SyncPanel.tsx
+++ b/src/features/groups/SyncPanel.tsx
@@ -319,8 +319,19 @@ export function SyncPanel({ groupId }: SyncPanelProps) {
             </div>
 
             {/* Status message */}
-            <div className="space-y-1">
+            <div className="space-y-2">
               <p className="text-sm">{sync.message}</p>
+              {sync.error && (
+                <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                  <div className="flex items-start gap-2">
+                    <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+                    <div>
+                      <p className="font-medium">Error de sincronització</p>
+                      <p>{sync.error}</p>
+                    </div>
+                  </div>
+                </div>
+              )}
               {(sync.remotePeerIds.length > 0 || sync.lastAttemptAt || sync.lastSuccessAt) && (
                 <div className="space-y-1 text-xs text-muted-foreground">
                   {sync.remotePeerIds.length > 0 && (
@@ -357,7 +368,7 @@ export function SyncPanel({ groupId }: SyncPanelProps) {
                   {copiedLink ? 'Enllaç copiat!' : 'Copiar enllaç de sync'}
                 </Button>
                 <p className="text-xs text-muted-foreground">
-                  O bé, manualment: obre Reparteix a l'altre dispositiu, ves al Sync del mateix grup, escriu la mateixa contrasenya i prem «Rebre».
+                  A l'altre dispositiu només cal obrir Reparteix al mateix grup, escriure la mateixa contrasenya i prémer «Sincronitzar».
                 </p>
               </div>
             )}

--- a/src/features/groups/SyncPanel.tsx
+++ b/src/features/groups/SyncPanel.tsx
@@ -281,12 +281,20 @@ export function SyncPanel({ groupId }: SyncPanelProps) {
         {sync.state === 'idle' && (
           <div className="space-y-2">
             <Button
-              onClick={() => handleStart('host')}
+              onClick={async () => {
+                setMode('host')
+                try {
+                  await persistPassphrase(passphrase)
+                  await sync.startSync()
+                } catch {
+                  // Error is handled by the sync hook
+                }
+              }}
               disabled={!canStart}
               className="w-full"
             >
               <RefreshCw className="h-4 w-4 mr-2" />
-              Sincronitzar
+              Sincronitzar ara
             </Button>
             <Button
               variant="outline"
@@ -295,7 +303,7 @@ export function SyncPanel({ groupId }: SyncPanelProps) {
               className="w-full"
             >
               <Wifi className="h-4 w-4 mr-2" />
-              Rebre des d'un enllaç o un altre dispositiu
+              Obrir en mode connexió manual
             </Button>
           </div>
         )}

--- a/src/features/groups/SyncPanel.tsx
+++ b/src/features/groups/SyncPanel.tsx
@@ -158,7 +158,7 @@ export function SyncPanel({ groupId }: SyncPanelProps) {
 
   const [passphrase, setPassphrase] = useState(rememberedPassphrase)
   const [showPassphrase, setShowPassphrase] = useState(false)
-  const [mode, setMode] = useState<'choose' | 'host' | 'join'>('choose')
+  const [mode, setMode] = useState<'idle' | 'host' | 'join'>('idle')
   const [copied, setCopied] = useState(false)
   const [copiedLink, setCopiedLink] = useState(false)
   const { loadGroups, loadGroupData } = useStore()
@@ -204,12 +204,12 @@ export function SyncPanel({ groupId }: SyncPanelProps) {
 
   const handleReset = () => {
     sync.reset()
-    setMode('choose')
+    setMode('idle')
   }
 
   const handleDone = async () => {
     sync.reset()
-    setMode('choose')
+    setMode('idle')
     setPassphrase('')
     // Reload data to reflect sync changes
     await loadGroups()
@@ -277,26 +277,25 @@ export function SyncPanel({ groupId }: SyncPanelProps) {
           </p>
         </div>
 
-        {/* Mode selection / active state */}
-        {mode === 'choose' && sync.state === 'idle' && (
-          <div className="grid grid-cols-2 gap-2">
+        {/* Phase 1 V2 UX: one primary sync action, with optional explicit receive path kept as secondary */}
+        {sync.state === 'idle' && (
+          <div className="space-y-2">
             <Button
-              variant="outline"
               onClick={() => handleStart('host')}
               disabled={!canStart}
-              className="flex-col h-auto py-3"
+              className="w-full"
             >
-              <Wifi className="h-5 w-5 mb-1" />
-              <span className="text-xs">Compartir</span>
+              <RefreshCw className="h-4 w-4 mr-2" />
+              Sincronitzar
             </Button>
             <Button
               variant="outline"
               onClick={() => handleStart('join')}
               disabled={!canStart}
-              className="flex-col h-auto py-3"
+              className="w-full"
             >
-              <RefreshCw className="h-5 w-5 mb-1" />
-              <span className="text-xs">Rebre</span>
+              <Wifi className="h-4 w-4 mr-2" />
+              Rebre des d'un enllaç o un altre dispositiu
             </Button>
           </div>
         )}
@@ -324,7 +323,14 @@ export function SyncPanel({ groupId }: SyncPanelProps) {
             </div>
 
             {/* Status message */}
-            <p className="text-sm">{sync.message}</p>
+            <div className="space-y-1">
+              <p className="text-sm">{sync.message}</p>
+              {sync.remotePeerIds.length > 0 && (
+                <p className="text-xs text-muted-foreground">
+                  Peers detectats: {sync.remotePeerIds.join(', ')}
+                </p>
+              )}
+            </div>
 
             {/* Instructions for host + share link */}
             {mode === 'host' && sync.state === 'waiting-for-peer' && (

--- a/src/hooks/useSync.ts
+++ b/src/hooks/useSync.ts
@@ -24,6 +24,10 @@ export interface UseSyncReturn {
   error: string | null
   /** Sync report with details of what changed */
   report: SyncReport | null
+  /** Last sync attempt timestamp */
+  lastAttemptAt: string | null
+  /** Last successful sync timestamp */
+  lastSuccessAt: string | null
   /** Sync v2 primary entry point: create room or join existing one */
   startSync: () => Promise<void>
   /** Start as host — create a room and wait for peer */
@@ -44,6 +48,8 @@ export function useSync({ groupId, passphrase, configOverrides }: UseSyncOptions
     passphrase,
     error: null,
     report: null,
+    lastAttemptAt: null,
+    lastSuccessAt: null,
     message: '',
   })
 
@@ -93,6 +99,8 @@ export function useSync({ groupId, passphrase, configOverrides }: UseSyncOptions
       passphrase,
       error: null,
       report: null,
+      lastAttemptAt: null,
+      lastSuccessAt: null,
       message: '',
     })
   }, [groupId, passphrase])
@@ -105,6 +113,8 @@ export function useSync({ groupId, passphrase, configOverrides }: UseSyncOptions
     message: status.message,
     error: status.error,
     report: status.report,
+    lastAttemptAt: status.lastAttemptAt,
+    lastSuccessAt: status.lastSuccessAt,
     startSync,
     startAsHost,
     joinSession,

--- a/src/hooks/useSync.ts
+++ b/src/hooks/useSync.ts
@@ -14,8 +14,10 @@ export interface UseSyncReturn {
   state: SyncSessionState
   /** Local peer ID (available after connecting to signaling server) */
   peerId: string | null
-  /** Remote peer ID (available after peer connects) */
+  /** Last remote peer ID seen by the session */
   remotePeerId: string | null
+  /** All remote peers currently known by the session */
+  remotePeerIds: string[]
   /** Human-readable status message */
   message: string
   /** Error message if state is 'error' */
@@ -35,6 +37,7 @@ export function useSync({ groupId, passphrase, configOverrides }: UseSyncOptions
     state: 'idle',
     peerId: null,
     remotePeerId: null,
+    remotePeerIds: [],
     groupId,
     passphrase,
     error: null,
@@ -78,6 +81,7 @@ export function useSync({ groupId, passphrase, configOverrides }: UseSyncOptions
       state: 'idle',
       peerId: null,
       remotePeerId: null,
+      remotePeerIds: [],
       groupId,
       passphrase,
       error: null,
@@ -90,6 +94,7 @@ export function useSync({ groupId, passphrase, configOverrides }: UseSyncOptions
     state: status.state,
     peerId: status.peerId,
     remotePeerId: status.remotePeerId,
+    remotePeerIds: status.remotePeerIds,
     message: status.message,
     error: status.error,
     report: status.report,

--- a/src/hooks/useSync.ts
+++ b/src/hooks/useSync.ts
@@ -7,6 +7,8 @@ export interface UseSyncOptions {
   groupId: string
   passphrase: string
   configOverrides?: SyncConfigOverrides
+  autoRetryEnabled?: boolean
+  autoRetryMs?: number
 }
 
 export interface UseSyncReturn {
@@ -28,6 +30,8 @@ export interface UseSyncReturn {
   lastAttemptAt: string | null
   /** Last successful sync timestamp */
   lastSuccessAt: string | null
+  /** Whether automatic retry is currently armed */
+  autoRetryEnabled: boolean
   /** Sync v2 primary entry point: create room or join existing one */
   startSync: () => Promise<void>
   /** Start as host — create a room and wait for peer */
@@ -38,7 +42,13 @@ export interface UseSyncReturn {
   reset: () => void
 }
 
-export function useSync({ groupId, passphrase, configOverrides }: UseSyncOptions): UseSyncReturn {
+export function useSync({
+  groupId,
+  passphrase,
+  configOverrides,
+  autoRetryEnabled = false,
+  autoRetryMs = 15000,
+}: UseSyncOptions): UseSyncReturn {
   const [status, setStatus] = useState<SyncSessionStatus>({
     state: 'idle',
     peerId: null,
@@ -54,10 +64,16 @@ export function useSync({ groupId, passphrase, configOverrides }: UseSyncOptions
   })
 
   const sessionRef = useRef<ReturnType<typeof createSyncSession> | null>(null)
+  const retryTimerRef = useRef<number | null>(null)
+  const retryInFlightRef = useRef(false)
 
   // Clean up on unmount or when key params change
   useEffect(() => {
     return () => {
+      if (retryTimerRef.current !== null) {
+        window.clearInterval(retryTimerRef.current)
+        retryTimerRef.current = null
+      }
       sessionRef.current?.destroy()
       sessionRef.current = null
     }
@@ -88,6 +104,10 @@ export function useSync({ groupId, passphrase, configOverrides }: UseSyncOptions
   }, [ensureSession])
 
   const reset = useCallback(() => {
+    if (retryTimerRef.current !== null) {
+      window.clearInterval(retryTimerRef.current)
+      retryTimerRef.current = null
+    }
     sessionRef.current?.destroy()
     sessionRef.current = null
     setStatus({
@@ -105,6 +125,47 @@ export function useSync({ groupId, passphrase, configOverrides }: UseSyncOptions
     })
   }, [groupId, passphrase])
 
+  useEffect(() => {
+    if (!autoRetryEnabled) {
+      if (retryTimerRef.current !== null) {
+        window.clearInterval(retryTimerRef.current)
+        retryTimerRef.current = null
+      }
+      return
+    }
+
+    if (retryTimerRef.current !== null) return
+
+    retryTimerRef.current = window.setInterval(() => {
+      if (document.visibilityState === 'hidden') return
+      if (retryInFlightRef.current) return
+      if (passphrase.trim().length < 4) return
+
+      const shouldRetry = status.state === 'error' || status.state === 'completed'
+      if (!shouldRetry) return
+
+      retryInFlightRef.current = true
+      void (async () => {
+        try {
+          reset()
+          const session = ensureSession()
+          await session.startSync()
+        } catch {
+          // surfaced by session status
+        } finally {
+          retryInFlightRef.current = false
+        }
+      })()
+    }, autoRetryMs)
+
+    return () => {
+      if (retryTimerRef.current !== null) {
+        window.clearInterval(retryTimerRef.current)
+        retryTimerRef.current = null
+      }
+    }
+  }, [autoRetryEnabled, autoRetryMs, ensureSession, passphrase, reset, status.state])
+
   return {
     state: status.state,
     peerId: status.peerId,
@@ -115,6 +176,7 @@ export function useSync({ groupId, passphrase, configOverrides }: UseSyncOptions
     report: status.report,
     lastAttemptAt: status.lastAttemptAt,
     lastSuccessAt: status.lastSuccessAt,
+    autoRetryEnabled,
     startSync,
     startAsHost,
     joinSession,

--- a/src/hooks/useSync.ts
+++ b/src/hooks/useSync.ts
@@ -24,6 +24,8 @@ export interface UseSyncReturn {
   error: string | null
   /** Sync report with details of what changed */
   report: SyncReport | null
+  /** Sync v2 primary entry point: create room or join existing one */
+  startSync: () => Promise<void>
   /** Start as host — create a room and wait for peer */
   startAsHost: () => Promise<void>
   /** Join an existing session as guest */
@@ -64,6 +66,11 @@ export function useSync({ groupId, passphrase, configOverrides }: UseSyncOptions
     return sessionRef.current
   }, [groupId, passphrase, configOverrides])
 
+  const startSync = useCallback(async () => {
+    const session = ensureSession()
+    await session.startSync()
+  }, [ensureSession])
+
   const startAsHost = useCallback(async () => {
     const session = ensureSession()
     await session.startAsHost()
@@ -98,6 +105,7 @@ export function useSync({ groupId, passphrase, configOverrides }: UseSyncOptions
     message: status.message,
     error: status.error,
     report: status.report,
+    startSync,
     startAsHost,
     joinSession,
     reset,

--- a/src/infra/sync/sync-session.ts
+++ b/src/infra/sync/sync-session.ts
@@ -48,6 +48,8 @@ export interface SyncSessionStatus {
   passphrase: string
   error: string | null
   report: SyncReport | null
+  lastAttemptAt: string | null
+  lastSuccessAt: string | null
   /** Human-readable progress message */
   message: string
 }
@@ -72,6 +74,8 @@ export function createSyncSession(
     passphrase,
     error: null,
     report: null,
+    lastAttemptAt: null,
+    lastSuccessAt: null,
     message: 'Inicialitzant…',
   }
 
@@ -248,6 +252,7 @@ export function createSyncSession(
       update({
         state: 'completed',
         report,
+        lastSuccessAt: new Date().toISOString(),
         message: buildReportSummary(report),
       })
     } catch (err) {
@@ -362,7 +367,12 @@ export function createSyncSession(
 
     /** Start as host: initialise peer and wait for a remote peer to connect. */
     async startAsHost(): Promise<string> {
-      update({ state: 'initializing', message: 'Connectant al servidor de senyalització…' })
+      update({
+        state: 'initializing',
+        lastAttemptAt: new Date().toISOString(),
+        error: null,
+        message: 'Connectant al servidor de senyalització…',
+      })
 
       try {
         const roomPeerId = await buildGroupPeerId()
@@ -382,7 +392,12 @@ export function createSyncSession(
 
     /** Start as guest: connect to the host peer and begin sync. */
     async joinSession(): Promise<void> {
-      update({ state: 'initializing', message: 'Connectant al servidor de senyalització…' })
+      update({
+        state: 'initializing',
+        lastAttemptAt: new Date().toISOString(),
+        error: null,
+        message: 'Connectant al servidor de senyalització…',
+      })
 
       try {
         await peerManager.init()
@@ -407,7 +422,12 @@ export function createSyncSession(
      */
     async startSync(): Promise<void> {
       const roomPeerId = await buildGroupPeerId()
-      update({ state: 'initializing', message: 'Preparant sincronització…' })
+      update({
+        state: 'initializing',
+        lastAttemptAt: new Date().toISOString(),
+        error: null,
+        message: 'Preparant sincronització…',
+      })
 
       try {
         const peerId = await peerManager.init(roomPeerId)

--- a/src/infra/sync/sync-session.ts
+++ b/src/infra/sync/sync-session.ts
@@ -43,6 +43,7 @@ export interface SyncSessionStatus {
   state: SyncSessionState
   peerId: string | null
   remotePeerId: string | null
+  remotePeerIds: string[]
   groupId: string
   passphrase: string
   error: string | null
@@ -66,6 +67,7 @@ export function createSyncSession(
     state: 'idle',
     peerId: null,
     remotePeerId: null,
+    remotePeerIds: [],
     groupId,
     passphrase,
     error: null,
@@ -78,6 +80,21 @@ export function createSyncSession(
     for (const listener of listeners) {
       listener(status)
     }
+  }
+
+  function addRemotePeer(remotePeerId: string) {
+    const remotePeerIds = status.remotePeerIds.includes(remotePeerId)
+      ? status.remotePeerIds
+      : [...status.remotePeerIds, remotePeerId]
+    update({ remotePeerId, remotePeerIds })
+  }
+
+  function removeRemotePeer(remotePeerId: string) {
+    const remotePeerIds = status.remotePeerIds.filter((id) => id !== remotePeerId)
+    update({
+      remotePeerIds,
+      remotePeerId: remotePeerIds.at(-1) ?? null,
+    })
   }
 
   // Build a group-specific peer ID prefix for discovery using SHA-256
@@ -162,8 +179,8 @@ export function createSyncSession(
       return
     }
 
+    addRemotePeer(remotePeerId)
     update({
-      remotePeerId,
       state: 'syncing',
       message: 'Connectat. Sincronitzant dades…',
     })
@@ -267,8 +284,8 @@ export function createSyncSession(
   }
 
   function handlePeerConnected(conn: PeerConnection) {
+    addRemotePeer(conn.peerId)
     update({
-      remotePeerId: conn.peerId,
       state: 'syncing',
       message: 'Peer connectat. Intercanviant dades…',
     })
@@ -277,10 +294,10 @@ export function createSyncSession(
     conn.send(createHelloMessage(peerManager.peerId!, [groupId]))
   }
 
-  function handlePeerDisconnected() {
+  function handlePeerDisconnected(remotePeerId: string) {
+    removeRemotePeer(remotePeerId)
     if (status.state !== 'completed' && status.state !== 'error') {
       update({
-        remotePeerId: null,
         state: 'error',
         error: 'Peer desconnectat',
         message: 'El peer s\'ha desconnectat abans de completar la sincronització.',

--- a/src/infra/sync/sync-session.ts
+++ b/src/infra/sync/sync-session.ts
@@ -402,6 +402,45 @@ export function createSyncSession(
       }
     },
 
+    /**
+     * Sync v2 entry point: try to create the room first, otherwise join the existing one.
+     */
+    async startSync(): Promise<void> {
+      const roomPeerId = await buildGroupPeerId()
+      update({ state: 'initializing', message: 'Preparant sincronització…' })
+
+      try {
+        const peerId = await peerManager.init(roomPeerId)
+        update({
+          state: 'waiting-for-peer',
+          peerId,
+          message: 'Sessió creada. Esperant que es connecti un altre dispositiu…',
+        })
+        return
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : 'Error inicialitzant'
+        if (!msg.includes('is taken') && !msg.includes('unavailable-id')) {
+          const friendly = err instanceof Error ? friendlyError(err) : 'Error inicialitzant'
+          update({ state: 'error', error: friendly, message: `Error: ${friendly}` })
+          throw err
+        }
+      }
+
+      try {
+        await peerManager.init()
+        update({
+          state: 'connecting',
+          peerId: peerManager.peerId,
+          message: 'Sessió existent detectada. Connectant per sincronitzar…',
+        })
+        await peerManager.connectTo(roomPeerId)
+      } catch (err) {
+        const msg = err instanceof Error ? friendlyError(err) : 'Error connectant'
+        update({ state: 'error', error: msg, message: `Error: ${msg}` })
+        throw err
+      }
+    },
+
     /** Clean up all resources. */
     destroy() {
       peerManager.destroy()


### PR DESCRIPTION
## Summary
- add ADR-002 for Sync v2
- define the product goal as a single "Sincronitzar" flow instead of send/receive
- define the technical direction toward multi-peer sync, periodic retries and CRDT-backed conflict resolution

## Why
PR #100 is a good Sync v1 line, but the requested next step changes the model enough that it deserves a separate track.

This PR creates that track with a concrete first artifact instead of leaving the v2 discussion only in comments.

## What ADR-002 covers
- multi-user / multi-device expectations
- periodic sync attempts
- advanced conflict resolution
- Yjs as initial candidate for replicated state
- phased rollout strategy to avoid a big-bang rewrite

## Relation to #100
- #100 stays as Sync v1
- this new PR starts the Sync v2 line on top of #100
