### PR TITLE
sync: simplify and polish group sync UI/UX

### DIFF
--- a/docs/sync-always-mode-ux-notes.md
+++ b/docs/sync-always-mode-ux-notes.md
@@ -1,0 +1,229 @@
+# Sync modes UX notes
+
+This note explores whether sync should become a per-group mode instead of a purely manual action.
+
+## Proposed modes
+
+### Off
+
+Use when:
+- the group is personal or single-device
+- the user does not want background sync
+- the user wants zero sync surface/noise
+
+UX implications:
+- no active sync badge
+- no retry/background behavior
+- sync action available only as an explicit setup/enable action
+
+### Manual
+
+Use when:
+- the user occasionally syncs between devices
+- the group is shared, but not continuously active
+- the user wants explicit control
+
+UX implications:
+- current product direction fits here
+- user presses a single action when needed
+- no continuous sync expectation
+
+### Always
+
+Use when:
+- the group is active across multiple devices or users
+- the user expects the group to stay fresh automatically
+- the app has connectivity and permission to keep trying
+
+UX implications:
+- sync becomes part of the group state, not only a one-shot action
+- app should attempt reconciliation whenever connectivity is available
+- local changes should enqueue sync quickly if the group is connected
+- UI must make status visible but calm
+
+## Product concerns
+
+### 1. Always mode changes the mental model
+
+Manual sync is an action.
+Always sync is a property of the group.
+
+That means the UX should likely move from:
+- "Do sync now"
+
+to:
+- "This group syncs automatically"
+- "Status: connected / pending / offline / error"
+
+### 2. Asking for sync mode during group creation can make sense, but only if lightweight
+
+If added too early, it will feel heavy.
+If added well, it can prevent later confusion.
+
+A reasonable creation flow could be:
+- Group name
+- Members / currency as today
+- Optional step: "Sincronització" with:
+  - Off
+  - Manual
+  - Always
+- If Manual or Always:
+  - ask for group password
+
+Alternative:
+- keep creation simple
+- after create, show a lightweight banner/card:
+  - "Vols activar sincronització per aquest grup?"
+
+This may be better for reducing setup friction.
+
+## Recommended model
+
+I would currently lean toward:
+
+### Default
+- new groups start in `off`
+
+### Activation
+- after group creation, offer:
+  - "Activar sincronització"
+
+### Then choose mode
+- Manual
+- Always
+
+Why:
+- avoids making every group creation heavier
+- keeps sync opt-in
+- still allows stronger setup for groups that need it
+
+## Group-level visibility
+
+A small group badge makes a lot of sense.
+
+Possible badge states:
+- `Sense sync`
+- `Sync manual`
+- `Sync automàtica`
+- `Sync pendent`
+- `Sync amb error`
+
+This badge should probably appear:
+- in group settings
+- optionally in the group header if mode is Always
+
+But it should stay subtle, not become top-level noise.
+
+## Behavior when changes happen
+
+If mode is Always, then yes: when local changes occur and connectivity exists, the app should try to sync.
+
+But from product perspective, this should likely be:
+- debounced/batched
+- not immediate per keystroke/action
+- visible as "pending" then "syncing" then "up to date"
+
+Recommended behavior:
+- local write happens
+- group enters `pending sync`
+- after short debounce/window, app tries to sync
+- if peer not reachable, keep calm pending/offline state and retry later
+
+## Mockup direction
+
+### Group settings
+
+**Sincronització**
+
+This group can stay in sync across devices.
+
+Mode:
+- Off
+- Manual
+- Always
+
+Password:
+[ ************* ]
+
+Status:
+- Up to date
+- Last sync 2 min ago
+
+[ Guardar configuració ]
+
+---
+
+### Group header badge idea
+
+`Sync automàtica · Al dia`
+`Sync manual`
+`Sync pendent`
+`Sync amb error`
+
+---
+
+### Always mode status block
+
+**Sincronització activada**
+Aquest grup es posa al dia automàticament quan hi ha connexió.
+
+Status: `Al dia`
+Last sync: `fa 2 min`
+
+[ Sincronitzar ara ]
+[ Veure detalls ]
+
+---
+
+### Pending/offline state
+
+**Sincronització automàtica**
+Hi ha canvis pendents. Es provarà de sincronitzar quan hi hagi connexió.
+
+Status: `Pendent`
+
+[ Sincronitzar ara ]
+
+## Risks
+
+### 1. Always mode can overpromise
+
+If browsers or devices sleep aggressively, users may interpret "always" as truly real-time.
+The product must frame it more honestly as:
+- automatic when possible
+- not guaranteed instant everywhere
+
+### 2. Password setup can add friction
+
+If the password is mandatory too early, group creation becomes heavier.
+This is why post-create activation may be better.
+
+### 3. Background sync changes architecture expectations
+
+Once Always exists, users will expect:
+- retries
+- status persistence
+- decent offline handling
+- fewer manual recovery steps
+
+So Always should not be introduced as just a label. It needs real runtime support.
+
+## Recommendation
+
+If we do this, I would aim for:
+
+1. keep sync outside the main functional tabs
+2. model sync as a per-group capability with `off / manual / always`
+3. expose a subtle badge/status on the group
+4. keep Manual as today's safer baseline
+5. introduce Always only with honest copy and pending/offline states
+
+## Short conclusion
+
+Yes, the idea makes sense.
+
+But:
+- `manual` is an action UX
+- `always` is a group-state UX
+
+So if we go there, the UI should evolve from a sync button into a lightweight status system for the group, not just a prettier modal.

--- a/docs/sync-ui-ux-plan.md
+++ b/docs/sync-ui-ux-plan.md
@@ -1,0 +1,133 @@
+# Sync UI/UX improvement pass
+
+This PR is the product/UI follow-up on top of the current sync implementation.
+
+## Goal
+
+Make sync feel like a natural part of the group instead of a technical side panel.
+
+The intended experience is:
+
+- simple
+- calm
+- obvious
+- confidence-building
+- usable by non-technical people
+
+## Product problems seen in the current UI
+
+### 1. Too much "panel/tool" feeling
+
+Right now sync still reads like an advanced feature block.
+It is functional, but not yet product-polished.
+
+### 2. The main action is clearer than before, but the screen still carries technical weight
+
+Even after moving to a single **Sincronitzar** action, the current surface still exposes:
+
+- too much operational status text
+- peer/runtime language too early
+- a card that feels secondary instead of core
+
+### 3. The sharing flow is useful but visually heavy
+
+The copy-link step is important, but the current presentation can be simplified and made more guided.
+
+### 4. Error and progress states can feel "engineering-first"
+
+They are informative, but not yet framed in the most reassuring product language.
+
+## Proposed UX direction
+
+### A. One primary sync block, more like a guided action
+
+Replace the current technical card feeling with a simpler flow:
+
+- title: **Sincronitzar grup**
+- one short explanation in plain language
+- password input
+- one clear primary action: **Sincronitzar**
+
+### B. Progress should read like intent, not transport internals
+
+Prefer messages like:
+
+- "Preparant sincronització..."
+- "Esperant l'altre dispositiu..."
+- "Connectant dispositius..."
+- "Posant dades al dia..."
+- "Grup sincronitzat"
+
+Avoid leading with low-level wording unless needed for diagnosis.
+
+### C. Diagnostics move to a secondary/details area
+
+Useful diagnostics should stay available, but visually demoted:
+
+- last sync
+- last error
+- peers seen
+- auto-retry active
+
+This can live under a subtle "Detalls" / secondary section.
+
+### D. Sharing should become a guided helper state
+
+When the host is waiting:
+
+- show one clear next step
+- show the share-link button prominently
+- reduce the wall of explanatory text
+
+Example direction:
+
+1. Prem **Copiar enllaç**
+2. Obre'l a l'altre dispositiu
+3. La sincronització començarà automàticament
+
+### E. Completion should feel calm and definitive
+
+After successful sync:
+
+- concise success state
+- short change summary if available
+- one obvious close/finish action
+
+### F. Sync should feel integrated with the group, not like a hidden admin area
+
+This PR should explore whether the current placement and visual hierarchy are good enough,
+or whether sync should feel more first-class inside the group experience.
+
+## Scope for this UX PR
+
+### In scope
+
+- simplify visual hierarchy of the sync surface
+- reduce technical wording in the main path
+- improve waiting/share state
+- improve success/error presentation
+- move diagnostics to a clearly secondary area
+- make the feature feel more polished and intentional
+
+### Out of scope
+
+- CRDT migration
+- transport/protocol redesign
+- auth/key-rotation redesign
+- relay infrastructure
+
+## Acceptance criteria
+
+- a non-technical user can understand what to do in a few seconds
+- the main path has one obvious action and one obvious next step
+- transport details are not the first thing the user sees
+- waiting, syncing, success and error states each have a clean presentation
+- the screen feels product-level, not debug-level
+
+## Suggested implementation slices
+
+1. simplify copy and state labels
+2. redesign waiting/share block
+3. demote diagnostics into secondary UI
+4. improve success/error layout
+5. validate final polish in preview

--- a/src/features/groups/GroupDetail.tsx
+++ b/src/features/groups/GroupDetail.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { ArrowLeft, Plus, X, Pencil, Check, Settings, Archive, RefreshCw } from 'lucide-react'
+import { ArrowLeft, Plus, X, Pencil, Check, Settings, Archive } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
@@ -10,7 +10,6 @@ import { useStore } from '../../store'
 import { ExpenseList } from '../expenses/ExpenseList'
 import { BalanceView } from '../balances/BalanceView'
 import { SettlementList } from '../settlements/SettlementList'
-import { SyncPanel } from './SyncPanel'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -292,10 +291,6 @@ export function GroupDetail() {
           <TabsTrigger value="settlements" className="flex-1">
             Pagaments
           </TabsTrigger>
-          <TabsTrigger value="sync" className="flex-1">
-            <RefreshCw className="h-3.5 w-3.5 mr-1" />
-            Sync
-          </TabsTrigger>
         </TabsList>
 
         <TabsContent value="expenses" className="flex-1 overflow-y-auto min-h-0 pb-4">
@@ -306,9 +301,6 @@ export function GroupDetail() {
         </TabsContent>
         <TabsContent value="settlements" className="flex-1 overflow-y-auto min-h-0 pb-4">
           <SettlementList group={group} />
-        </TabsContent>
-        <TabsContent value="sync" className="flex-1 overflow-y-auto min-h-0 pb-4 pt-4">
-          <SyncPanel groupId={group.id} />
         </TabsContent>
       </Tabs>
       </div>

--- a/src/features/groups/SyncPanel.tsx
+++ b/src/features/groups/SyncPanel.tsx
@@ -236,13 +236,13 @@ export function SyncPanel({ groupId }: SyncPanelProps) {
       <CardHeader>
         <CardTitle className="text-base flex items-center gap-2">
           <RefreshCw className="h-4 w-4" />
-          Sincronització P2P
+          Sincronitzar grup
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
         <p className="text-sm text-muted-foreground">
-          Sincronitza les dades del grup amb un altre dispositiu directament, sense servidor.
-          Tots dos dispositius han d'usar la mateixa contrasenya.
+          Posa aquest grup al dia entre dispositius amb una sola acció.
+          Si l'altre dispositiu és a punt, la sincronització començarà automàticament.
         </p>
 
         {/* Passphrase input */}
@@ -273,7 +273,7 @@ export function SyncPanel({ groupId }: SyncPanelProps) {
             </div>
           </div>
           <p className="text-xs text-muted-foreground">
-            La contrasenya queda guardada en aquest grup i també al navegador d'aquest dispositiu.
+            Aquesta contrasenya es guarda al grup i en aquest dispositiu perquè no l'hagis d'escriure cada vegada.
           </p>
         </div>
 
@@ -320,7 +320,7 @@ export function SyncPanel({ groupId }: SyncPanelProps) {
 
             {/* Status message */}
             <div className="space-y-2">
-              <p className="text-sm">{sync.message}</p>
+              <p className="text-sm font-medium">{sync.message}</p>
               {sync.error && (
                 <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
                   <div className="flex items-start gap-2">
@@ -333,30 +333,41 @@ export function SyncPanel({ groupId }: SyncPanelProps) {
                 </div>
               )}
               {(sync.remotePeerIds.length > 0 || sync.lastAttemptAt || sync.lastSuccessAt) && (
-                <div className="space-y-1 text-xs text-muted-foreground">
-                  {sync.remotePeerIds.length > 0 && (
-                    <p>Peers detectats: {sync.remotePeerIds.join(', ')}</p>
-                  )}
-                  {sync.lastAttemptAt && (
-                    <p>Últim intent: {formatSyncTimestamp(sync.lastAttemptAt)}</p>
-                  )}
-                  {sync.lastSuccessAt && (
-                    <p>Última sync correcta: {formatSyncTimestamp(sync.lastSuccessAt)}</p>
-                  )}
-                  {sync.autoRetryEnabled && (
-                    <p>Reintent automàtic actiu mentre aquest panell estigui obert</p>
-                  )}
-                </div>
+                <details className="rounded-md bg-muted/60 px-3 py-2 text-xs text-muted-foreground">
+                  <summary className="cursor-pointer select-none font-medium text-foreground/80">
+                    Detalls de sincronització
+                  </summary>
+                  <div className="mt-2 space-y-1">
+                    {sync.remotePeerIds.length > 0 && (
+                      <p>Dispositius detectats: {sync.remotePeerIds.join(', ')}</p>
+                    )}
+                    {sync.lastAttemptAt && (
+                      <p>Últim intent: {formatSyncTimestamp(sync.lastAttemptAt)}</p>
+                    )}
+                    {sync.lastSuccessAt && (
+                      <p>Última sincronització correcta: {formatSyncTimestamp(sync.lastSuccessAt)}</p>
+                    )}
+                    {sync.autoRetryEnabled && (
+                      <p>Reintent automàtic actiu mentre aquest panell estigui obert</p>
+                    )}
+                  </div>
+                </details>
               )}
             </div>
 
             {/* Instructions for host + share link */}
             {mode === 'host' && sync.state === 'waiting-for-peer' && (
-              <div className="rounded-md bg-muted p-3 text-sm space-y-3">
-                <p className="font-medium">Per sincronitzar:</p>
-                <ol className="list-decimal list-inside space-y-1 text-muted-foreground">
-                  <li>Comparteix l'enllaç amb l'altre dispositiu</li>
-                  <li>L'altre dispositiu obrirà l'enllaç i es connectarà automàticament</li>
+              <div className="rounded-lg border bg-muted/50 p-4 text-sm space-y-3">
+                <div className="space-y-1">
+                  <p className="font-medium">Falta l'altre dispositiu</p>
+                  <p className="text-muted-foreground">
+                    Comparteix aquest enllaç i la sincronització començarà quan l'obrin.
+                  </p>
+                </div>
+                <ol className="space-y-1 text-muted-foreground">
+                  <li>1. Copia l'enllaç</li>
+                  <li>2. Obre'l a l'altre dispositiu</li>
+                  <li>3. Reparteix es connectarà i posarà el grup al dia</li>
                 </ol>
                 <Button
                   variant="outline"
@@ -365,17 +376,21 @@ export function SyncPanel({ groupId }: SyncPanelProps) {
                   className="w-full"
                 >
                   {copiedLink ? <Check className="h-4 w-4 mr-2" /> : <Link2 className="h-4 w-4 mr-2" />}
-                  {copiedLink ? 'Enllaç copiat!' : 'Copiar enllaç de sync'}
+                  {copiedLink ? 'Enllaç copiat!' : 'Copiar enllaç'}
                 </Button>
                 <p className="text-xs text-muted-foreground">
-                  A l'altre dispositiu només cal obrir Reparteix al mateix grup, escriure la mateixa contrasenya i prémer «Sincronitzar».
+                  Si prefereixes, també pots obrir Reparteix a l'altre dispositiu, entrar al mateix grup i prémer «Sincronitzar» amb la mateixa contrasenya.
                 </p>
               </div>
             )}
 
             {/* Sync report */}
             {sync.report && (
-              <div className="rounded-md bg-muted p-3">
+              <div className="rounded-lg border bg-success/5 p-3">
+                <div className="mb-2 flex items-center gap-2 text-sm font-medium text-success">
+                  <CheckCircle2 className="h-4 w-4" />
+                  Grup sincronitzat
+                </div>
                 <SyncReportDetails report={sync.report} />
               </div>
             )}


### PR DESCRIPTION
## Summary
- open a dedicated follow-up PR for sync UI/UX improvements
- add a concrete UX plan for making sync simpler, calmer and more usable
- define acceptance criteria and implementation slices for the UI pass

## Why
The current sync flow is much better than before, but it still feels too much like a technical panel.

This PR creates a clean place to improve the product experience on top of #100 without mixing UI/UX polish with the transport/runtime work.

## Included now
- new document: `docs/sync-ui-ux-plan.md`
- product problems observed in the current UI
- target UX direction
- acceptance criteria
- suggested slices for implementation

## Next
Use this PR to implement the visual and interaction improvements incrementally on top of #100.
