### PR TITLE
perf: reduce initial bundle with lazy-loaded routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,16 @@
-import { useEffect } from 'react'
+import { lazy, Suspense, useEffect } from 'react'
 import { HashRouter, Routes, Route, useNavigate } from 'react-router-dom'
-import { GroupList } from './features/groups/GroupList'
-import { GroupDetail } from './features/groups/GroupDetail'
-import { GroupSettings } from './features/groups/GroupSettings'
-import { ImportFromUrl } from './features/groups/ImportFromUrl'
-import { OnboardingWizard } from './features/groups/OnboardingWizard'
-import { SyncFromUrl } from './features/groups/SyncFromUrl'
 import { PWAUpdatePrompt } from './components/PWAUpdatePrompt'
 import { PWAInstallPrompt } from './components/PWAInstallPrompt'
 import { Footer } from './components/Footer'
 import { useFileHandler } from './hooks/useFileHandler'
+
+const GroupList = lazy(() => import('./features/groups/GroupList').then((m) => ({ default: m.GroupList })))
+const GroupDetail = lazy(() => import('./features/groups/GroupDetail').then((m) => ({ default: m.GroupDetail })))
+const GroupSettings = lazy(() => import('./features/groups/GroupSettings').then((m) => ({ default: m.GroupSettings })))
+const ImportFromUrl = lazy(() => import('./features/groups/ImportFromUrl').then((m) => ({ default: m.ImportFromUrl })))
+const OnboardingWizard = lazy(() => import('./features/groups/OnboardingWizard').then((m) => ({ default: m.OnboardingWizard })))
+const SyncFromUrl = lazy(() => import('./features/groups/SyncFromUrl').then((m) => ({ default: m.SyncFromUrl })))
 
 function FileHandlerBridge() {
   const navigate = useNavigate()
@@ -44,20 +45,30 @@ function App() {
   return (
     <HashRouter>
       <div className="flex min-h-screen flex-col">
-        <Routes>
-          <Route path="/" element={<GroupList />} />
-          <Route path="/onboarding" element={<OnboardingWizard />} />
-          <Route path="/group/:groupId" element={<GroupDetail />} />
-          <Route path="/group/:groupId/settings" element={<GroupSettings />} />
-          <Route path="/import" element={<ImportFromUrl />} />
-          <Route path="/sync" element={<SyncFromUrl />} />
-        </Routes>
+        <Suspense fallback={<RouteLoadingFallback />}>
+          <Routes>
+            <Route path="/" element={<GroupList />} />
+            <Route path="/onboarding" element={<OnboardingWizard />} />
+            <Route path="/group/:groupId" element={<GroupDetail />} />
+            <Route path="/group/:groupId/settings" element={<GroupSettings />} />
+            <Route path="/import" element={<ImportFromUrl />} />
+            <Route path="/sync" element={<SyncFromUrl />} />
+          </Routes>
+        </Suspense>
         <Footer />
       </div>
       <FileHandlerBridge />
       <PWAInstallPrompt />
       <PWAUpdatePrompt />
     </HashRouter>
+  )
+}
+
+function RouteLoadingFallback() {
+  return (
+    <div className="flex flex-1 items-center justify-center p-6 text-sm text-muted-foreground">
+      Carregant…
+    </div>
   )
 }
 

--- a/src/features/groups/GroupSettings.tsx
+++ b/src/features/groups/GroupSettings.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { lazy, Suspense, useEffect, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { ArrowLeft, Trash2, Download, Share2, Archive, ArchiveRestore } from 'lucide-react'
 import { Button } from '@/components/ui/button'
@@ -21,7 +21,7 @@ import {
 import { Separator } from '@/components/ui/separator'
 import { useStore } from '../../store'
 import { reparteix } from '../../sdk'
-import { SyncPanel } from './SyncPanel'
+const SyncPanel = lazy(() => import('./SyncPanel').then((m) => ({ default: m.SyncPanel })))
 import type { Group } from '../../domain/entities'
 
 const EMOJI_SHORTCUTS = [
@@ -256,7 +256,9 @@ function GroupSettingsForm({ group, groupId }: GroupSettingsFormProps) {
 
       <Separator className="my-8" />
 
-      <SyncPanel groupId={groupId} />
+      <Suspense fallback={<p className="text-sm text-muted-foreground">Carregant sincronització…</p>}>
+        <SyncPanel groupId={groupId} />
+      </Suspense>
 
       <Separator className="my-8" />
 


### PR DESCRIPTION
## Summary
- lazy-load route screens instead of shipping them in the initial bundle
- lazy-load the sync UI inside group settings
- keep sync and import flows out of the critical path for first render

## Why
Issue #106 tracks the oversized initial chunk after the sync work landed.

This PR attacks the highest-leverage cut first: route-level code splitting and lazy loading of sync-specific UI.

## Validation
- npm test ✅
- npm run build ✅
- initial entry chunk reduced from ~649 kB to ~233 kB
- sync surfaces now load in separate chunks instead of the main entry bundle

Closes #106