### PR TITLE
feat: add native PWA sharing and share target

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Configuració a `.releaserc.json`, workflow a `.github/workflows/release.yml`.
 2. **Local-first** — l'app funciona 100% offline, dades a IndexedDB.
 3. **Soft delete** — les entitats es marquen com `deleted: true`, mai s'esborren físicament.
 4. **HashRouter** — per compatibilitat amb hosting estàtic (GitHub Pages).
-5. **PWA** — instal·lable i amb service worker per a cache offline.
+5. **PWA** — instal·lable, amb service worker per a cache offline, Web Share per compartir enllaços i suport de recepció de fitxers `.reparteix.json` via share target / file handling segons el navegador.
 
 ## Manteniment de la documentació
 

--- a/public/share-target.html
+++ b/public/share-target.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="ca">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Reparteix · Important…</title>
+  </head>
+  <body>
+    <script>
+      ;(async function () {
+        try {
+          const formData = await new Response(document.body, {
+            headers: { 'Content-Type': document.contentType || 'multipart/form-data' },
+          }).formData()
+          const file = formData.get('file')
+
+          if (!(file instanceof File)) {
+            throw new Error('No s\'ha rebut cap fitxer per compartir')
+          }
+
+          const text = await file.text()
+          sessionStorage.setItem(
+            'reparteix.share-target.pending',
+            JSON.stringify({ name: file.name, type: file.type, text }),
+          )
+          location.replace('./#/import/shared')
+        } catch (err) {
+          sessionStorage.setItem(
+            'reparteix.share-target.pending',
+            JSON.stringify({
+              error: err instanceof Error ? err.message : 'No s\'ha pogut processar el fitxer compartit',
+            }),
+          )
+          location.replace('./#/import/shared')
+        }
+      })()
+    </script>
+  </body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ const GroupSettings = lazy(() => import('./features/groups/GroupSettings').then(
 const ImportFromUrl = lazy(() => import('./features/groups/ImportFromUrl').then((m) => ({ default: m.ImportFromUrl })))
 const OnboardingWizard = lazy(() => import('./features/groups/OnboardingWizard').then((m) => ({ default: m.OnboardingWizard })))
 const SyncFromUrl = lazy(() => import('./features/groups/SyncFromUrl').then((m) => ({ default: m.SyncFromUrl })))
+const ShareTargetImport = lazy(() => import('./features/groups/ShareTargetImport').then((m) => ({ default: m.ShareTargetImport })))
 
 function FileHandlerBridge() {
   const navigate = useNavigate()
@@ -52,6 +53,7 @@ function App() {
             <Route path="/group/:groupId" element={<GroupDetail />} />
             <Route path="/group/:groupId/settings" element={<GroupSettings />} />
             <Route path="/import" element={<ImportFromUrl />} />
+            <Route path="/import/shared" element={<ShareTargetImport />} />
             <Route path="/sync" element={<SyncFromUrl />} />
           </Routes>
         </Suspense>

--- a/src/features/groups/GroupSettings.tsx
+++ b/src/features/groups/GroupSettings.tsx
@@ -21,6 +21,7 @@ import {
 import { Separator } from '@/components/ui/separator'
 import { useStore } from '../../store'
 import { reparteix } from '../../sdk'
+import { shareUrl } from '@/lib/web-share'
 const SyncPanel = lazy(() => import('./SyncPanel').then((m) => ({ default: m.SyncPanel })))
 import type { Group } from '../../domain/entities'
 
@@ -93,7 +94,11 @@ function GroupSettingsForm({ group, groupId }: GroupSettingsFormProps) {
     try {
       const encoded = await reparteix.share.encodeGroup(groupId)
       const url = `${window.location.origin}${window.location.pathname}#/import?g=${encoded}`
-      await navigator.clipboard.writeText(url)
+      await shareUrl({
+        title: `Grup ${group.name} · Reparteix`,
+        text: `Importa el grup \"${group.name}\" a Reparteix`,
+        url,
+      })
       setShareStatus('ok')
     } catch {
       setShareStatus('error')
@@ -243,10 +248,10 @@ function GroupSettingsForm({ group, groupId }: GroupSettingsFormProps) {
             onClick={handleShare}
           >
             <Share2 className="h-4 w-4 mr-2" />
-            Copiar enllaç
+            Compartir grup
           </Button>
           {shareStatus === 'ok' && (
-            <p className="text-sm text-success">Enllaç copiat al porta-retalls.</p>
+            <p className="text-sm text-success">Enllaç preparat i compartit correctament.</p>
           )}
           {shareStatus === 'error' && (
             <p className="text-sm text-destructive">Error en generar l'enllaç. Torna-ho a intentar.</p>

--- a/src/features/groups/GroupSettings.tsx
+++ b/src/features/groups/GroupSettings.tsx
@@ -47,7 +47,7 @@ function GroupSettingsForm({ group, groupId }: GroupSettingsFormProps) {
   const [icon, setIcon] = useState(group.icon ?? '')
   const [currency, setCurrency] = useState(group.currency)
   const [exportStatus, setExportStatus] = useState<'idle' | 'ok' | 'error'>('idle')
-  const [shareStatus, setShareStatus] = useState<'idle' | 'ok' | 'error'>('idle')
+  const [shareStatus, setShareStatus] = useState<'idle' | 'shared' | 'copied' | 'error'>('idle')
 
   const isArchived = group.archived
 
@@ -94,12 +94,13 @@ function GroupSettingsForm({ group, groupId }: GroupSettingsFormProps) {
     try {
       const encoded = await reparteix.share.encodeGroup(groupId)
       const url = `${window.location.origin}${window.location.pathname}#/import?g=${encoded}`
-      await shareUrl({
+      const result = await shareUrl({
         title: `Grup ${group.name} · Reparteix`,
         text: `Importa el grup "${group.name}" a Reparteix`,
         url,
       })
-      setShareStatus('ok')
+      if (result.method === 'cancelled') return
+      setShareStatus(result.method === 'clipboard' ? 'copied' : 'shared')
     } catch {
       setShareStatus('error')
     } finally {
@@ -250,8 +251,11 @@ function GroupSettingsForm({ group, groupId }: GroupSettingsFormProps) {
             <Share2 className="h-4 w-4 mr-2" />
             Compartir grup
           </Button>
-          {shareStatus === 'ok' && (
-            <p className="text-sm text-success">Enllaç preparat i compartit correctament.</p>
+          {shareStatus === 'shared' && (
+            <p className="text-sm text-success">Enllaç compartit correctament.</p>
+          )}
+          {shareStatus === 'copied' && (
+            <p className="text-sm text-success">Enllaç copiat al porta-retalls.</p>
           )}
           {shareStatus === 'error' && (
             <p className="text-sm text-destructive">Error en generar l'enllaç. Torna-ho a intentar.</p>

--- a/src/features/groups/GroupSettings.tsx
+++ b/src/features/groups/GroupSettings.tsx
@@ -96,7 +96,7 @@ function GroupSettingsForm({ group, groupId }: GroupSettingsFormProps) {
       const url = `${window.location.origin}${window.location.pathname}#/import?g=${encoded}`
       await shareUrl({
         title: `Grup ${group.name} · Reparteix`,
-        text: `Importa el grup \"${group.name}\" a Reparteix`,
+        text: `Importa el grup "${group.name}" a Reparteix`,
         url,
       })
       setShareStatus('ok')

--- a/src/features/groups/ShareTargetImport.tsx
+++ b/src/features/groups/ShareTargetImport.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { AlertCircle } from 'lucide-react'
+import { clearPendingSharedFile, loadPendingSharedFile } from '@/lib/share-target'
+import { useStore } from '@/store'
+import { Card, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+
+type State =
+  | { status: 'loading' }
+  | { status: 'error'; message: string }
+  | { status: 'done'; groupId: string }
+
+export function ShareTargetImport() {
+  const navigate = useNavigate()
+  const importGroup = useStore((state) => state.importGroup)
+  const [state, setState] = useState<State>({ status: 'loading' })
+
+  useEffect(() => {
+    const pending = loadPendingSharedFile()
+
+    if (!pending) {
+      setState({ status: 'error', message: 'No hi ha cap fitxer compartit pendent.' })
+      return
+    }
+
+    if (pending.error) {
+      clearPendingSharedFile()
+      setState({ status: 'error', message: pending.error })
+      return
+    }
+
+    if (!pending.text) {
+      clearPendingSharedFile()
+      setState({ status: 'error', message: 'El fitxer compartit no conté dades llegibles.' })
+      return
+    }
+
+    const text = pending.text
+
+    ;(async () => {
+      try {
+        const raw: unknown = JSON.parse(text)
+        const group = await importGroup(raw)
+        clearPendingSharedFile()
+        setState({ status: 'done', groupId: group.id })
+      } catch (err) {
+        setState({
+          status: 'error',
+          message: err instanceof Error ? err.message : 'No s\'ha pogut importar el fitxer compartit.',
+        })
+      }
+    })()
+  }, [importGroup])
+
+  return (
+    <div className="min-h-screen bg-muted/50 px-4 py-10">
+      <div className="mx-auto max-w-xl">
+        <Card className="shadow-md">
+          <CardContent className="py-10 text-center">
+            {state.status === 'loading' && (
+              <p className="text-muted-foreground">Important fitxer compartit…</p>
+            )}
+
+            {state.status === 'error' && (
+              <div className="flex flex-col items-center gap-4">
+                <AlertCircle className="h-10 w-10 text-destructive" />
+                <div>
+                  <p className="font-semibold text-destructive">No s'ha pogut importar</p>
+                  <p className="mt-1 text-sm text-muted-foreground">{state.message}</p>
+                </div>
+                <Button variant="outline" onClick={() => navigate('/')}>
+                  Tornar a l'inici
+                </Button>
+              </div>
+            )}
+
+            {state.status === 'done' && (
+              <div className="flex flex-col items-center gap-4">
+                <p className="font-semibold text-success">Grup importat correctament</p>
+                <Button onClick={() => navigate(`/group/${state.groupId}`)}>
+                  Veure el grup
+                </Button>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/src/features/groups/ShareTargetImport.tsx
+++ b/src/features/groups/ShareTargetImport.tsx
@@ -7,36 +7,39 @@ import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 
 type State =
-  | { status: 'loading' }
+  | { status: 'loading'; text: string }
   | { status: 'error'; message: string }
   | { status: 'done'; groupId: string }
+
+function getInitialState(): State {
+  const pending = loadPendingSharedFile()
+
+  if (!pending) {
+    return { status: 'error', message: 'No hi ha cap fitxer compartit pendent.' }
+  }
+
+  if (pending.error) {
+    clearPendingSharedFile()
+    return { status: 'error', message: pending.error }
+  }
+
+  if (!pending.text) {
+    clearPendingSharedFile()
+    return { status: 'error', message: 'El fitxer compartit no conté dades llegibles.' }
+  }
+
+  return { status: 'loading', text: pending.text }
+}
 
 export function ShareTargetImport() {
   const navigate = useNavigate()
   const importGroup = useStore((state) => state.importGroup)
-  const [state, setState] = useState<State>({ status: 'loading' })
+  const [state, setState] = useState<State>(() => getInitialState())
 
   useEffect(() => {
-    const pending = loadPendingSharedFile()
+    if (state.status !== 'loading') return
 
-    if (!pending) {
-      setState({ status: 'error', message: 'No hi ha cap fitxer compartit pendent.' })
-      return
-    }
-
-    if (pending.error) {
-      clearPendingSharedFile()
-      setState({ status: 'error', message: pending.error })
-      return
-    }
-
-    if (!pending.text) {
-      clearPendingSharedFile()
-      setState({ status: 'error', message: 'El fitxer compartit no conté dades llegibles.' })
-      return
-    }
-
-    const text = pending.text
+    const text = state.text
 
     ;(async () => {
       try {
@@ -51,7 +54,7 @@ export function ShareTargetImport() {
         })
       }
     })()
-  }, [importGroup])
+  }, [importGroup, state])
 
   return (
     <div className="min-h-screen bg-muted/50 px-4 py-10">

--- a/src/features/groups/SyncPanel.tsx
+++ b/src/features/groups/SyncPanel.tsx
@@ -26,6 +26,7 @@ import { useSync } from '@/hooks/useSync'
 import { useStore } from '@/store'
 import { encodeBase64Url } from '@/lib/base64url'
 import { loadStoredSyncPassphrase, saveStoredSyncPassphrase } from '@/lib/sync-passphrase'
+import { shareUrl } from '@/lib/web-share'
 import type { SyncReport } from '@/domain/services/sync'
 
 interface SyncPanelProps {
@@ -226,7 +227,11 @@ export function SyncPanel({ groupId }: SyncPanelProps) {
 
   const handleCopySyncLink = async () => {
     const url = buildSyncUrl(groupId, passphrase)
-    await navigator.clipboard.writeText(url)
+    await shareUrl({
+      title: `Sync de grup · Reparteix`,
+      text: 'Obre aquest enllaç a l\'altre dispositiu per sincronitzar el grup a Reparteix',
+      url,
+    })
     setCopiedLink(true)
     setTimeout(() => setCopiedLink(false), 3000)
   }
@@ -376,7 +381,7 @@ export function SyncPanel({ groupId }: SyncPanelProps) {
                   className="w-full"
                 >
                   {copiedLink ? <Check className="h-4 w-4 mr-2" /> : <Link2 className="h-4 w-4 mr-2" />}
-                  {copiedLink ? 'Enllaç copiat!' : 'Copiar enllaç'}
+                  {copiedLink ? 'Enllaç compartit!' : 'Compartir enllaç'}
                 </Button>
                 <p className="text-xs text-muted-foreground">
                   Si prefereixes, també pots obrir Reparteix a l'altre dispositiu, entrar al mateix grup i prémer «Sincronitzar» amb la mateixa contrasenya.

--- a/src/features/groups/SyncPanel.tsx
+++ b/src/features/groups/SyncPanel.tsx
@@ -174,7 +174,7 @@ export function SyncPanel({ groupId }: SyncPanelProps) {
   const [showPassphrase, setShowPassphrase] = useState(false)
   const [mode, setMode] = useState<'idle' | 'host' | 'join'>('idle')
   const [copied, setCopied] = useState(false)
-  const [copiedLink, setCopiedLink] = useState(false)
+  const [sharedLinkStatus, setSharedLinkStatus] = useState<'idle' | 'shared' | 'copied'>('idle')
   const { loadGroups, loadGroupData } = useStore()
 
   const sync = useSync({
@@ -227,13 +227,14 @@ export function SyncPanel({ groupId }: SyncPanelProps) {
 
   const handleCopySyncLink = async () => {
     const url = buildSyncUrl(groupId, passphrase)
-    await shareUrl({
+    const result = await shareUrl({
       title: `Sync de grup · Reparteix`,
       text: 'Obre aquest enllaç a l\'altre dispositiu per sincronitzar el grup a Reparteix',
       url,
     })
-    setCopiedLink(true)
-    setTimeout(() => setCopiedLink(false), 3000)
+    if (result.method === 'cancelled') return
+    setSharedLinkStatus(result.method === 'clipboard' ? 'copied' : 'shared')
+    setTimeout(() => setSharedLinkStatus('idle'), 3000)
   }
 
   return (
@@ -380,8 +381,8 @@ export function SyncPanel({ groupId }: SyncPanelProps) {
                   onClick={handleCopySyncLink}
                   className="w-full"
                 >
-                  {copiedLink ? <Check className="h-4 w-4 mr-2" /> : <Link2 className="h-4 w-4 mr-2" />}
-                  {copiedLink ? 'Enllaç compartit!' : 'Compartir enllaç'}
+                  {sharedLinkStatus !== 'idle' ? <Check className="h-4 w-4 mr-2" /> : <Link2 className="h-4 w-4 mr-2" />}
+                  {sharedLinkStatus === 'shared' ? 'Enllaç compartit!' : sharedLinkStatus === 'copied' ? 'Enllaç copiat!' : 'Compartir enllaç'}
                 </Button>
                 <p className="text-xs text-muted-foreground">
                   Si prefereixes, també pots obrir Reparteix a l'altre dispositiu, entrar al mateix grup i prémer «Sincronitzar» amb la mateixa contrasenya.

--- a/src/lib/share-target.ts
+++ b/src/lib/share-target.ts
@@ -1,0 +1,24 @@
+const SHARE_TARGET_KEY = 'reparteix.share-target.pending'
+
+export interface PendingSharedFile {
+  name?: string
+  type?: string
+  text?: string
+  error?: string
+}
+
+export function loadPendingSharedFile(): PendingSharedFile | null {
+  const raw = window.sessionStorage.getItem(SHARE_TARGET_KEY)
+  if (!raw) return null
+
+  try {
+    return JSON.parse(raw) as PendingSharedFile
+  } catch {
+    window.sessionStorage.removeItem(SHARE_TARGET_KEY)
+    return null
+  }
+}
+
+export function clearPendingSharedFile(): void {
+  window.sessionStorage.removeItem(SHARE_TARGET_KEY)
+}

--- a/src/lib/web-share.ts
+++ b/src/lib/web-share.ts
@@ -1,17 +1,28 @@
 export interface ShareResult {
-  method: 'native-share' | 'clipboard'
+  method: 'native-share' | 'clipboard' | 'cancelled'
 }
 
 function supportsNativeShare(): boolean {
   return typeof navigator !== 'undefined' && typeof navigator.share === 'function'
 }
 
+function isShareAbort(error: unknown): boolean {
+  return error instanceof DOMException && error.name === 'AbortError'
+}
+
 export async function shareUrl(
   data: { title?: string; text?: string; url: string },
 ): Promise<ShareResult> {
   if (supportsNativeShare()) {
-    await navigator.share(data)
-    return { method: 'native-share' }
+    try {
+      await navigator.share(data)
+      return { method: 'native-share' }
+    } catch (error) {
+      if (isShareAbort(error)) {
+        return { method: 'cancelled' }
+      }
+      throw error
+    }
   }
 
   await navigator.clipboard.writeText(data.url)

--- a/src/lib/web-share.ts
+++ b/src/lib/web-share.ts
@@ -1,0 +1,19 @@
+export interface ShareResult {
+  method: 'native-share' | 'clipboard'
+}
+
+function supportsNativeShare(): boolean {
+  return typeof navigator !== 'undefined' && typeof navigator.share === 'function'
+}
+
+export async function shareUrl(
+  data: { title?: string; text?: string; url: string },
+): Promise<ShareResult> {
+  if (supportsNativeShare()) {
+    await navigator.share(data)
+    return { method: 'native-share' }
+  }
+
+  await navigator.clipboard.writeText(data.url)
+  return { method: 'clipboard' }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -55,6 +55,19 @@ export default defineConfig({
             },
           },
         ],
+        share_target: {
+          action: `${basePath}share-target`,
+          method: 'POST',
+          enctype: 'multipart/form-data',
+          params: {
+            files: [
+              {
+                name: 'file',
+                accept: ['application/json', 'application/vnd.reparteix+json', '.reparteix.json'],
+              },
+            ],
+          },
+        },
       },
       workbox: {
         globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],


### PR DESCRIPTION
Closes #108

## Summary
- use the native share sheet for group share links and sync links when navigator.share is available
- keep clipboard fallback for browsers without Web Share API support
- add a PWA share_target flow so Reparteix can receive shared `.reparteix.json` files and import them

## Validation
- npm test
- npm run build
