### PR TITLE
fix: chunk large sync payloads

### DIFF
--- a/src/infra/sync/protocol.test.ts
+++ b/src/infra/sync/protocol.test.ts
@@ -3,6 +3,7 @@ import {
   createHelloMessage,
   createRequestSyncMessage,
   createSyncDataMessage,
+  createSyncDataChunkMessage,
   createSyncAckMessage,
   createErrorMessage,
   encodeMessage,
@@ -31,6 +32,18 @@ describe('sync protocol', () => {
       const payload = { iv: 'aWY=', ciphertext: 'Y2lwaGVy', salt: 'c2FsdA==' }
       const msg = createSyncDataMessage('group-a', payload)
       expect(msg).toEqual({ type: 'sync-data', groupId: 'group-a', payload })
+    })
+
+    it('creates a sync-data-chunk message', () => {
+      const msg = createSyncDataChunkMessage('group-a', 'transfer-1', 0, 3, 'chunk-1')
+      expect(msg).toEqual({
+        type: 'sync-data-chunk',
+        groupId: 'group-a',
+        transferId: 'transfer-1',
+        index: 0,
+        total: 3,
+        chunk: 'chunk-1',
+      })
     })
 
     it('creates a sync-ack message with ok status', () => {
@@ -76,6 +89,13 @@ describe('sync protocol', () => {
     it('round-trips a sync-data message', () => {
       const payload = { iv: 'aWY=', ciphertext: 'Y2lwaGVy', salt: 'c2FsdA==' }
       const original = createSyncDataMessage('group-x', payload)
+      const encoded = encodeMessage(original)
+      const decoded = decodeMessage(encoded)
+      expect(decoded).toEqual(original)
+    })
+
+    it('round-trips a sync-data-chunk message', () => {
+      const original = createSyncDataChunkMessage('group-x', 'transfer-2', 1, 4, 'payload-slice')
       const encoded = encodeMessage(original)
       const decoded = decodeMessage(encoded)
       expect(decoded).toEqual(original)

--- a/src/infra/sync/protocol.test.ts
+++ b/src/infra/sync/protocol.test.ts
@@ -8,6 +8,8 @@ import {
   createErrorMessage,
   encodeMessage,
   decodeMessage,
+  MAX_SYNC_DATA_CHUNKS,
+  MAX_SYNC_DATA_CHUNK_LENGTH,
   SYNC_PROTOCOL_VERSION,
 } from './protocol'
 
@@ -148,6 +150,45 @@ describe('sync protocol', () => {
       expect(decodeMessage(42)).toBeNull()
       expect(decodeMessage(null)).toBeNull()
       expect(decodeMessage(undefined)).toBeNull()
+    })
+
+    it('returns null for sync-data-chunk with index out of range', () => {
+      expect(
+        decodeMessage({
+          type: 'sync-data-chunk',
+          groupId: 'group-x',
+          transferId: 'transfer-1',
+          index: 3,
+          total: 3,
+          chunk: 'abc',
+        }),
+      ).toBeNull()
+    })
+
+    it('returns null for sync-data-chunk with too many chunks', () => {
+      expect(
+        decodeMessage({
+          type: 'sync-data-chunk',
+          groupId: 'group-x',
+          transferId: 'transfer-1',
+          index: 0,
+          total: MAX_SYNC_DATA_CHUNKS + 1,
+          chunk: 'abc',
+        }),
+      ).toBeNull()
+    })
+
+    it('returns null for sync-data-chunk with chunk payload too large', () => {
+      expect(
+        decodeMessage({
+          type: 'sync-data-chunk',
+          groupId: 'group-x',
+          transferId: 'transfer-1',
+          index: 0,
+          total: 1,
+          chunk: 'a'.repeat(MAX_SYNC_DATA_CHUNK_LENGTH + 1),
+        }),
+      ).toBeNull()
     })
   })
 })

--- a/src/infra/sync/protocol.ts
+++ b/src/infra/sync/protocol.ts
@@ -33,6 +33,15 @@ const SyncDataMessageSchema = z.object({
   payload: EncryptedPayloadSchema,
 })
 
+const SyncDataChunkMessageSchema = z.object({
+  type: z.literal('sync-data-chunk'),
+  groupId: z.string(),
+  transferId: z.string(),
+  index: z.number().int().min(0),
+  total: z.number().int().positive(),
+  chunk: z.string(),
+})
+
 const SyncAckMessageSchema = z.object({
   type: z.literal('sync-ack'),
   groupId: z.string(),
@@ -50,6 +59,7 @@ export const SyncMessageSchema = z.discriminatedUnion('type', [
   HelloMessageSchema,
   RequestSyncMessageSchema,
   SyncDataMessageSchema,
+  SyncDataChunkMessageSchema,
   SyncAckMessageSchema,
   ErrorMessageSchema,
 ])
@@ -59,6 +69,7 @@ export const SyncMessageSchema = z.discriminatedUnion('type', [
 export type HelloMessage = z.infer<typeof HelloMessageSchema>
 export type RequestSyncMessage = z.infer<typeof RequestSyncMessageSchema>
 export type SyncDataMessage = z.infer<typeof SyncDataMessageSchema>
+export type SyncDataChunkMessage = z.infer<typeof SyncDataChunkMessageSchema>
 export type SyncAckMessage = z.infer<typeof SyncAckMessageSchema>
 export type ErrorMessage = z.infer<typeof ErrorMessageSchema>
 export type SyncMessage = z.infer<typeof SyncMessageSchema>
@@ -83,6 +94,16 @@ export function createSyncDataMessage(
   payload: EncryptedPayload,
 ): SyncDataMessage {
   return { type: 'sync-data', groupId, payload }
+}
+
+export function createSyncDataChunkMessage(
+  groupId: string,
+  transferId: string,
+  index: number,
+  total: number,
+  chunk: string,
+): SyncDataChunkMessage {
+  return { type: 'sync-data-chunk', groupId, transferId, index, total, chunk }
 }
 
 export function createSyncAckMessage(

--- a/src/infra/sync/protocol.ts
+++ b/src/infra/sync/protocol.ts
@@ -33,14 +33,27 @@ const SyncDataMessageSchema = z.object({
   payload: EncryptedPayloadSchema,
 })
 
-const SyncDataChunkMessageSchema = z.object({
-  type: z.literal('sync-data-chunk'),
-  groupId: z.string(),
-  transferId: z.string(),
-  index: z.number().int().min(0),
-  total: z.number().int().positive(),
-  chunk: z.string(),
-})
+export const MAX_SYNC_DATA_CHUNKS = 1024
+export const MAX_SYNC_DATA_CHUNK_LENGTH = 8_000
+
+const SyncDataChunkMessageSchema = z
+  .object({
+    type: z.literal('sync-data-chunk'),
+    groupId: z.string(),
+    transferId: z.string(),
+    index: z.number().int().min(0),
+    total: z.number().int().positive().max(MAX_SYNC_DATA_CHUNKS),
+    chunk: z.string().min(1).max(MAX_SYNC_DATA_CHUNK_LENGTH),
+  })
+  .superRefine((value, ctx) => {
+    if (value.index >= value.total) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['index'],
+        message: 'Chunk index must be less than total chunks',
+      })
+    }
+  })
 
 const SyncAckMessageSchema = z.object({
   type: z.literal('sync-ack'),

--- a/src/infra/sync/sync-session.ts
+++ b/src/infra/sync/sync-session.ts
@@ -117,7 +117,10 @@ export function createSyncSession(
   }
 
   const config = createSyncConfig(configOverrides)
-  const MAX_SYNC_CHUNK_SIZE = 24_000
+  // Conservative per-message payload size. The practical JSON channel limit is
+  // lower than the raw PeerJS transport limit once protocol/message overhead is
+  // included, so keep chunks comfortably small.
+  const MAX_SYNC_CHUNK_SIZE = 8_000
   const incomingPayloadChunks = new Map<string, { groupId: string; total: number; chunks: string[] }>()
 
   function buildTransferId(): string {

--- a/src/infra/sync/sync-session.ts
+++ b/src/infra/sync/sync-session.ts
@@ -16,6 +16,7 @@ import {
   createHelloMessage,
   createRequestSyncMessage,
   createSyncDataMessage,
+  createSyncDataChunkMessage,
   createSyncAckMessage,
   createErrorMessage,
   SYNC_PROTOCOL_VERSION,
@@ -116,6 +117,75 @@ export function createSyncSession(
   }
 
   const config = createSyncConfig(configOverrides)
+  const MAX_SYNC_CHUNK_SIZE = 24_000
+  const incomingPayloadChunks = new Map<string, { groupId: string; total: number; chunks: string[] }>()
+
+  function buildTransferId(): string {
+    if (typeof globalThis.crypto?.randomUUID === 'function') {
+      return globalThis.crypto.randomUUID()
+    }
+    return `sync-${Date.now()}-${Math.random().toString(16).slice(2)}`
+  }
+
+  async function sendEncryptedPayload(conn: PeerConnection, targetGroupId: string, payload: EncryptedPayload) {
+    const serializedPayload = JSON.stringify(payload)
+
+    if (serializedPayload.length <= MAX_SYNC_CHUNK_SIZE) {
+      conn.send(createSyncDataMessage(targetGroupId, payload))
+      return
+    }
+
+    const transferId = buildTransferId()
+    const total = Math.ceil(serializedPayload.length / MAX_SYNC_CHUNK_SIZE)
+
+    for (let index = 0; index < total; index++) {
+      const chunk = serializedPayload.slice(index * MAX_SYNC_CHUNK_SIZE, (index + 1) * MAX_SYNC_CHUNK_SIZE)
+      conn.send(createSyncDataChunkMessage(targetGroupId, transferId, index, total, chunk))
+    }
+  }
+
+  async function handleSyncDataChunk(
+    remotePeerId: string,
+    receivedGroupId: string,
+    transferId: string,
+    index: number,
+    total: number,
+    chunk: string,
+  ) {
+    if (receivedGroupId !== groupId) {
+      const conn = peerManager.connections.get(remotePeerId)
+      conn?.send(createSyncAckMessage(receivedGroupId, 'error', 'Grup no correspon'))
+      return
+    }
+
+    const existing = incomingPayloadChunks.get(transferId)
+    const transfer = existing ?? { groupId: receivedGroupId, total, chunks: Array.from({ length: total }, () => '') }
+
+    if (transfer.total !== total) {
+      incomingPayloadChunks.delete(transferId)
+      throw new Error('Transferència fragmentada inconsistent')
+    }
+
+    transfer.chunks[index] = chunk
+    incomingPayloadChunks.set(transferId, transfer)
+
+    const isComplete = transfer.chunks.every(Boolean)
+    if (!isComplete) {
+      update({ message: `Rebent dades grans… (${index + 1}/${total})` })
+      return
+    }
+
+    incomingPayloadChunks.delete(transferId)
+
+    let payload: EncryptedPayload
+    try {
+      payload = JSON.parse(transfer.chunks.join('')) as EncryptedPayload
+    } catch {
+      throw new Error('No s\'han pogut reconstruir les dades rebudes')
+    }
+
+    await handleSyncData(remotePeerId, receivedGroupId, payload)
+  }
 
   /** Translate common PeerJS errors to user-friendly Catalan messages. */
   function friendlyError(err: Error): string {
@@ -162,6 +232,16 @@ export function createSyncSession(
           break
         case 'sync-data':
           await handleSyncData(remotePeerId, message.groupId, message.payload)
+          break
+        case 'sync-data-chunk':
+          await handleSyncDataChunk(
+            remotePeerId,
+            message.groupId,
+            message.transferId,
+            message.index,
+            message.total,
+            message.chunk,
+          )
           break
         case 'sync-ack':
           handleSyncAck(message)
@@ -218,7 +298,7 @@ export function createSyncSession(
       // Encrypt and send
       const json = JSON.stringify(envelope)
       const encrypted = await encryptSyncPayload(passphrase, json)
-      conn.send(createSyncDataMessage(groupId, encrypted))
+      await sendEncryptedPayload(conn, groupId, encrypted)
       update({ message: 'Dades enviades. Esperant resposta…' })
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Error preparant dades'

--- a/src/infra/sync/sync-session.ts
+++ b/src/infra/sync/sync-session.ts
@@ -19,6 +19,8 @@ import {
   createSyncDataChunkMessage,
   createSyncAckMessage,
   createErrorMessage,
+  MAX_SYNC_DATA_CHUNKS,
+  MAX_SYNC_DATA_CHUNK_LENGTH,
   SYNC_PROTOCOL_VERSION,
   type SyncMessage,
 } from './protocol'
@@ -120,8 +122,15 @@ export function createSyncSession(
   // Conservative per-message payload size. The practical JSON channel limit is
   // lower than the raw PeerJS transport limit once protocol/message overhead is
   // included, so keep chunks comfortably small.
-  const MAX_SYNC_CHUNK_SIZE = 8_000
-  const incomingPayloadChunks = new Map<string, { groupId: string; total: number; chunks: string[] }>()
+  const MAX_SYNC_CHUNK_SIZE = MAX_SYNC_DATA_CHUNK_LENGTH
+  const MAX_INCOMING_TRANSFER_AGE_MS = 60_000
+  const incomingPayloadChunks = new Map<string, {
+    remotePeerId: string
+    groupId: string
+    total: number
+    chunks: string[]
+    createdAt: number
+  }>()
 
   function buildTransferId(): string {
     if (typeof globalThis.crypto?.randomUUID === 'function') {
@@ -130,19 +139,66 @@ export function createSyncSession(
     return `sync-${Date.now()}-${Math.random().toString(16).slice(2)}`
   }
 
-  async function sendEncryptedPayload(conn: PeerConnection, targetGroupId: string, payload: EncryptedPayload) {
-    const serializedPayload = JSON.stringify(payload)
+  function getEncodedMessageLength(message: SyncMessage): number {
+    return JSON.stringify(message).length
+  }
 
-    if (serializedPayload.length <= MAX_SYNC_CHUNK_SIZE) {
-      conn.send(createSyncDataMessage(targetGroupId, payload))
+  function cleanupExpiredIncomingTransfers() {
+    const now = Date.now()
+    for (const [key, transfer] of incomingPayloadChunks.entries()) {
+      if (now - transfer.createdAt > MAX_INCOMING_TRANSFER_AGE_MS) {
+        incomingPayloadChunks.delete(key)
+      }
+    }
+  }
+
+  async function sendEncryptedPayload(conn: PeerConnection, targetGroupId: string, payload: EncryptedPayload) {
+    const syncDataMessage = createSyncDataMessage(targetGroupId, payload)
+
+    if (getEncodedMessageLength(syncDataMessage) <= MAX_SYNC_CHUNK_SIZE) {
+      conn.send(syncDataMessage)
       return
     }
 
+    const serializedPayload = JSON.stringify(payload)
     const transferId = buildTransferId()
-    const total = Math.ceil(serializedPayload.length / MAX_SYNC_CHUNK_SIZE)
+    const chunks: string[] = []
+    let cursor = 0
 
-    for (let index = 0; index < total; index++) {
-      const chunk = serializedPayload.slice(index * MAX_SYNC_CHUNK_SIZE, (index + 1) * MAX_SYNC_CHUNK_SIZE)
+    while (cursor < serializedPayload.length) {
+      const index = chunks.length
+      const remainingLength = serializedPayload.length - cursor
+      let low = 1
+      let high = remainingLength
+      let bestLength = 0
+
+      while (low <= high) {
+        const middle = Math.floor((low + high) / 2)
+        const candidateChunk = serializedPayload.slice(cursor, cursor + middle)
+        const candidateMessage = createSyncDataChunkMessage(targetGroupId, transferId, index, 1, candidateChunk)
+
+        if (getEncodedMessageLength(candidateMessage) <= MAX_SYNC_CHUNK_SIZE) {
+          bestLength = middle
+          low = middle + 1
+        } else {
+          high = middle - 1
+        }
+      }
+
+      if (bestLength === 0) {
+        throw new Error('No s\'ha pogut fragmentar el missatge dins del límit del canal')
+      }
+
+      chunks.push(serializedPayload.slice(cursor, cursor + bestLength))
+      cursor += bestLength
+    }
+
+    if (chunks.length > MAX_SYNC_DATA_CHUNKS) {
+      throw new Error('El grup és massa gran per sincronitzar-lo amb aquest canal actual')
+    }
+
+    const total = chunks.length
+    for (const [index, chunk] of chunks.entries()) {
       conn.send(createSyncDataChunkMessage(targetGroupId, transferId, index, total, chunk))
     }
   }
@@ -155,30 +211,46 @@ export function createSyncSession(
     total: number,
     chunk: string,
   ) {
+    const conn = peerManager.connections.get(remotePeerId)
+
     if (receivedGroupId !== groupId) {
-      const conn = peerManager.connections.get(remotePeerId)
       conn?.send(createSyncAckMessage(receivedGroupId, 'error', 'Grup no correspon'))
       return
     }
 
-    const existing = incomingPayloadChunks.get(transferId)
-    const transfer = existing ?? { groupId: receivedGroupId, total, chunks: Array.from({ length: total }, () => '') }
+    if (total > MAX_SYNC_DATA_CHUNKS || chunk.length > MAX_SYNC_DATA_CHUNK_LENGTH || index < 0 || index >= total) {
+      conn?.send(createSyncAckMessage(receivedGroupId, 'error', 'Fragments de sync invàlids'))
+      return
+    }
 
-    if (transfer.total !== total) {
-      incomingPayloadChunks.delete(transferId)
-      throw new Error('Transferència fragmentada inconsistent')
+    cleanupExpiredIncomingTransfers()
+
+    const transferKey = `${remotePeerId}:${transferId}`
+    const existing = incomingPayloadChunks.get(transferKey)
+    const transfer = existing ?? {
+      remotePeerId,
+      groupId: receivedGroupId,
+      total,
+      chunks: Array.from({ length: total }, () => ''),
+      createdAt: Date.now(),
+    }
+
+    if (transfer.total !== total || transfer.remotePeerId !== remotePeerId || transfer.groupId !== receivedGroupId) {
+      incomingPayloadChunks.delete(transferKey)
+      conn?.send(createSyncAckMessage(receivedGroupId, 'error', 'Transferència fragmentada inconsistent'))
+      return
     }
 
     transfer.chunks[index] = chunk
-    incomingPayloadChunks.set(transferId, transfer)
+    incomingPayloadChunks.set(transferKey, transfer)
 
-    const isComplete = transfer.chunks.every(Boolean)
+    const isComplete = transfer.chunks.every((value) => value.length > 0)
     if (!isComplete) {
       update({ message: `Rebent dades grans… (${index + 1}/${total})` })
       return
     }
 
-    incomingPayloadChunks.delete(transferId)
+    incomingPayloadChunks.delete(transferKey)
 
     let payload: EncryptedPayload
     try {
@@ -384,6 +456,11 @@ export function createSyncSession(
 
   function handlePeerDisconnected(remotePeerId: string) {
     removeRemotePeer(remotePeerId)
+    for (const [key, transfer] of incomingPayloadChunks.entries()) {
+      if (transfer.remotePeerId === remotePeerId) {
+        incomingPayloadChunks.delete(key)
+      }
+    }
     if (status.state !== 'completed' && status.state !== 'error') {
       update({
         state: 'error',


### PR DESCRIPTION
## Summary
- add app-level chunk messages for large encrypted sync payloads
- reconstruct fragmented payloads before decrypt/apply on the receiver
- keep the simple single-message path for small payloads

## Why
Issue #111 reports  when syncing large groups.

The current transport sends the encrypted snapshot as one JSON message. This PR adds a safe fallback path for large payloads by fragmenting the encrypted payload string into smaller protocol messages and reassembling it on the receiver.

## Validation
- npm test ✅
- npm run build ✅
- protocol tests expanded for chunk messages

Closes #111