### PR TITLE
fix: avoid false successful PR previews

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -80,24 +80,38 @@ jobs:
           fi
 
           PR_DIR="pr-${PR_NUMBER}"
-          git clone --depth 1 "https://x-access-token:${STAGING_TOKEN}@github.com/reparteix/staging.git" /tmp/staging
+          STAGING_DIR="/tmp/staging-${PR_NUMBER}"
+          rm -rf "${STAGING_DIR}"
+          git clone --depth 1 "https://x-access-token:${STAGING_TOKEN}@github.com/reparteix/staging.git" "${STAGING_DIR}"
 
-          # Remove previous preview if it exists, then copy new build
-          rm -rf "/tmp/staging/${PR_DIR}"
-          cp -r dist "/tmp/staging/${PR_DIR}"
+          rm -rf "${STAGING_DIR}/${PR_DIR}"
+          cp -r dist "${STAGING_DIR}/${PR_DIR}"
+          touch "${STAGING_DIR}/.nojekyll"
 
-          # Ensure .nojekyll exists at repo root
-          touch /tmp/staging/.nojekyll
-
-          cd /tmp/staging
+          cd "${STAGING_DIR}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
           if git diff --cached --quiet; then
             echo "No changes to commit"
-          else
-            git commit -m "deploy: update preview for PR #${PR_NUMBER}"
-            git push origin main
+            echo "deployed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git commit -m "deploy: update preview for PR #${PR_NUMBER}"
+          git push origin main
+
+          REMOTE_HEAD=$(git ls-remote origin refs/heads/main | cut -f1)
+          LOCAL_HEAD=$(git rev-parse HEAD)
+
+          if [ -z "${REMOTE_HEAD}" ]; then
+            echo "::error::Could not resolve remote staging main after push"
+            exit 1
+          fi
+
+          if [ "${REMOTE_HEAD}" != "${LOCAL_HEAD}" ]; then
+            echo "::error::Staging main is not yet at pushed commit ${LOCAL_HEAD} (remote: ${REMOTE_HEAD})"
+            exit 1
           fi
 
           echo "deployed=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -71,8 +71,11 @@ jobs:
           STAGING_TOKEN: ${{ secrets.STAGING_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          set -euo pipefail
+
           if [ -z "${STAGING_TOKEN}" ]; then
             echo "::warning::STAGING_TOKEN is not set. Skipping preview deployment. Add the secret in repository settings."
+            echo "deployed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -97,8 +100,10 @@ jobs:
             git push origin main
           fi
 
+          echo "deployed=true" >> "$GITHUB_OUTPUT"
+
       - name: Set deployment status to success
-        if: success()
+        if: success() && steps.deploy.outputs.deployed == 'true'
         uses: actions/github-script@v8
         with:
           script: |
@@ -127,6 +132,7 @@ jobs:
             });
 
       - name: Comment on PR with preview URL
+        if: success() && steps.deploy.outputs.deployed == 'true'
         uses: actions/github-script@v8
         with:
           script: |


### PR DESCRIPTION
Closes #129

## Summary
- track whether the staging preview was actually deployed
- only mark the deployment as success when staging deploy succeeded
- only comment with the preview URL when staging deploy succeeded

## Why
The preview workflow could skip or fail the staging deploy but still look deployed in GitHub and comment with a preview URL.

## Testing
- reviewed workflow conditions and outputs
- checked success/comment steps now require `steps.deploy.outputs.deployed == "true"`