### PR TITLE
refactor: use compact header sync action with mobile sheet

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -71,53 +71,34 @@ jobs:
           STAGING_TOKEN: ${{ secrets.STAGING_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          set -euo pipefail
-
           if [ -z "${STAGING_TOKEN}" ]; then
             echo "::warning::STAGING_TOKEN is not set. Skipping preview deployment. Add the secret in repository settings."
-            echo "deployed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           PR_DIR="pr-${PR_NUMBER}"
-          STAGING_DIR="/tmp/staging-${PR_NUMBER}"
-          rm -rf "${STAGING_DIR}"
-          git clone --depth 1 "https://x-access-token:${STAGING_TOKEN}@github.com/reparteix/staging.git" "${STAGING_DIR}"
+          git clone --depth 1 "https://x-access-token:${STAGING_TOKEN}@github.com/reparteix/staging.git" /tmp/staging
 
-          rm -rf "${STAGING_DIR}/${PR_DIR}"
-          cp -r dist "${STAGING_DIR}/${PR_DIR}"
-          touch "${STAGING_DIR}/.nojekyll"
+          # Remove previous preview if it exists, then copy new build
+          rm -rf "/tmp/staging/${PR_DIR}"
+          cp -r dist "/tmp/staging/${PR_DIR}"
 
-          cd "${STAGING_DIR}"
+          # Ensure .nojekyll exists at repo root
+          touch /tmp/staging/.nojekyll
+
+          cd /tmp/staging
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
           if git diff --cached --quiet; then
             echo "No changes to commit"
-            echo "deployed=true" >> "$GITHUB_OUTPUT"
-            exit 0
+          else
+            git commit -m "deploy: update preview for PR #${PR_NUMBER}"
+            git push origin main
           fi
-
-          git commit -m "deploy: update preview for PR #${PR_NUMBER}"
-          git push origin main
-
-          REMOTE_HEAD=$(git ls-remote origin refs/heads/main | cut -f1)
-          LOCAL_HEAD=$(git rev-parse HEAD)
-
-          if [ -z "${REMOTE_HEAD}" ]; then
-            echo "::error::Could not resolve remote staging main after push"
-            exit 1
-          fi
-
-          if [ "${REMOTE_HEAD}" != "${LOCAL_HEAD}" ]; then
-            echo "::error::Staging main is not yet at pushed commit ${LOCAL_HEAD} (remote: ${REMOTE_HEAD})"
-            exit 1
-          fi
-
-          echo "deployed=true" >> "$GITHUB_OUTPUT"
 
       - name: Set deployment status to success
-        if: success() && steps.deploy.outputs.deployed == 'true'
+        if: success()
         uses: actions/github-script@v8
         with:
           script: |
@@ -146,7 +127,6 @@ jobs:
             });
 
       - name: Comment on PR with preview URL
-        if: success() && steps.deploy.outputs.deployed == 'true'
         uses: actions/github-script@v8
         with:
           script: |

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -80,24 +80,38 @@ jobs:
           fi
 
           PR_DIR="pr-${PR_NUMBER}"
-          git clone --depth 1 "https://x-access-token:${STAGING_TOKEN}@github.com/reparteix/staging.git" /tmp/staging
+          STAGING_DIR="/tmp/staging-${PR_NUMBER}"
+          rm -rf "${STAGING_DIR}"
+          git clone --depth 1 "https://x-access-token:${STAGING_TOKEN}@github.com/reparteix/staging.git" "${STAGING_DIR}"
 
-          # Remove previous preview if it exists, then copy new build
-          rm -rf "/tmp/staging/${PR_DIR}"
-          cp -r dist "/tmp/staging/${PR_DIR}"
+          rm -rf "${STAGING_DIR}/${PR_DIR}"
+          cp -r dist "${STAGING_DIR}/${PR_DIR}"
+          touch "${STAGING_DIR}/.nojekyll"
 
-          # Ensure .nojekyll exists at repo root
-          touch /tmp/staging/.nojekyll
-
-          cd /tmp/staging
+          cd "${STAGING_DIR}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
           if git diff --cached --quiet; then
             echo "No changes to commit"
-          else
-            git commit -m "deploy: update preview for PR #${PR_NUMBER}"
-            git push origin main
+            echo "deployed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git commit -m "deploy: update preview for PR #${PR_NUMBER}"
+          git push origin main
+
+          REMOTE_HEAD=$(git ls-remote origin refs/heads/main | cut -f1)
+          LOCAL_HEAD=$(git rev-parse HEAD)
+
+          if [ -z "${REMOTE_HEAD}" ]; then
+            echo "::error::Could not resolve remote staging main after push"
+            exit 1
+          fi
+
+          if [ "${REMOTE_HEAD}" != "${LOCAL_HEAD}" ]; then
+            echo "::error::Staging main is not yet at pushed commit ${LOCAL_HEAD} (remote: ${REMOTE_HEAD})"
+            exit 1
           fi
 
           echo "deployed=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -71,8 +71,11 @@ jobs:
           STAGING_TOKEN: ${{ secrets.STAGING_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          set -euo pipefail
+
           if [ -z "${STAGING_TOKEN}" ]; then
             echo "::warning::STAGING_TOKEN is not set. Skipping preview deployment. Add the secret in repository settings."
+            echo "deployed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -97,8 +100,10 @@ jobs:
             git push origin main
           fi
 
+          echo "deployed=true" >> "$GITHUB_OUTPUT"
+
       - name: Set deployment status to success
-        if: success()
+        if: success() && steps.deploy.outputs.deployed == 'true'
         uses: actions/github-script@v8
         with:
           script: |
@@ -127,6 +132,7 @@ jobs:
             });
 
       - name: Comment on PR with preview URL
+        if: success() && steps.deploy.outputs.deployed == 'true'
         uses: actions/github-script@v8
         with:
           script: |

--- a/src/features/groups/GroupDetail.tsx
+++ b/src/features/groups/GroupDetail.tsx
@@ -99,6 +99,12 @@ export function GroupDetail() {
     setEditingName('')
   }
 
+  useEffect(() => {
+    if (showSyncModal) {
+      syncModalRef.current?.focus()
+    }
+  }, [showSyncModal])
+
   if (!group) {
     return (
       <div className="max-w-2xl mx-auto p-4">
@@ -108,12 +114,6 @@ export function GroupDetail() {
   }
 
   const activeMembers = group.members.filter((m) => !m.deleted)
-
-  useEffect(() => {
-    if (showSyncModal) {
-      syncModalRef.current?.focus()
-    }
-  }, [showSyncModal])
 
   return (
     <div className="fixed inset-0 bg-background overflow-hidden flex flex-col">

--- a/src/features/groups/GroupDetail.tsx
+++ b/src/features/groups/GroupDetail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { lazy, Suspense, useEffect, useRef, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { ArrowLeft, Plus, X, Pencil, Check, Settings, Archive, RefreshCw, Smartphone } from 'lucide-react'
 import { Button } from '@/components/ui/button'
@@ -22,6 +22,8 @@ import {
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog'
 
+const SyncPanel = lazy(() => import('./SyncPanel').then((m) => ({ default: m.SyncPanel })))
+
 export function GroupDetail() {
   const { groupId } = useParams<{ groupId: string }>()
   const navigate = useNavigate()
@@ -39,6 +41,8 @@ export function GroupDetail() {
   const [showAddMember, setShowAddMember] = useState(false)
   const [editingMemberId, setEditingMemberId] = useState<string | null>(null)
   const [editingName, setEditingName] = useState('')
+  const [showSyncModal, setShowSyncModal] = useState(false)
+  const syncModalRef = useRef<HTMLDivElement>(null)
 
   const group = groups.find((g) => g.id === groupId)
   const isArchived = group?.archived ?? false
@@ -105,6 +109,12 @@ export function GroupDetail() {
 
   const activeMembers = group.members.filter((m) => !m.deleted)
 
+  useEffect(() => {
+    if (showSyncModal) {
+      syncModalRef.current?.focus()
+    }
+  }, [showSyncModal])
+
   return (
     <div className="fixed inset-0 bg-background overflow-hidden flex flex-col">
       <div className="flex-1 max-w-2xl mx-auto w-full flex flex-col min-h-0 px-4">
@@ -160,17 +170,17 @@ export function GroupDetail() {
                 Continuïtat entre dispositius
               </div>
               <p className="mt-1 text-sm text-indigo-950/80 dark:text-indigo-100/80">
-                Si vols posar aquest grup al dia en un altre mòbil o ordinador, ves a <strong>Configuració → Sincronitzar grup</strong> i comparteix l&apos;enllaç de sync.
+                Posa aquest grup al dia en un altre mòbil o ordinador directament des d&apos;aquí. Si encara no tens contrasenya de grup, la pots definir abans de començar.
               </p>
             </div>
             <Button
               variant="outline"
               size="sm"
-              onClick={() => navigate(`/group/${groupId}/settings`)}
+              onClick={() => setShowSyncModal(true)}
               className="shrink-0 border-indigo-300 bg-white/80 text-indigo-700 hover:bg-white dark:border-indigo-800 dark:bg-indigo-950/60 dark:text-indigo-200"
             >
               <RefreshCw className="h-4 w-4 mr-1" />
-              Sincronitzar
+              Obrir sync
             </Button>
           </div>
         </div>
@@ -329,6 +339,50 @@ export function GroupDetail() {
         </TabsContent>
       </Tabs>
       </div>
+
+      {showSyncModal && !isArchived && (
+        <div
+          ref={syncModalRef}
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Sincronitzar grup"
+          tabIndex={-1}
+          onClick={() => setShowSyncModal(false)}
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') {
+              setShowSyncModal(false)
+            }
+          }}
+        >
+          <div
+            className="w-full max-w-xl max-h-[90vh] overflow-y-auto rounded-2xl bg-background p-4 shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="mb-4 flex items-start justify-between gap-3">
+              <div>
+                <h2 className="text-lg font-semibold">Sincronitzar grup</h2>
+                <p className="text-sm text-muted-foreground">
+                  Comparteix el grup amb un altre dispositiu sense sortir d&apos;aquesta vista.
+                </p>
+              </div>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                onClick={() => setShowSyncModal(false)}
+                aria-label="Tancar sincronització"
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+
+            <Suspense fallback={<p className="text-sm text-muted-foreground">Carregant sincronització…</p>}>
+              <SyncPanel groupId={group.id} />
+            </Suspense>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/features/groups/GroupDetail.tsx
+++ b/src/features/groups/GroupDetail.tsx
@@ -41,6 +41,7 @@ export function GroupDetail() {
   const [editingMemberId, setEditingMemberId] = useState<string | null>(null)
   const [editingName, setEditingName] = useState('')
   const [showSyncModal, setShowSyncModal] = useState(false)
+  const [isSyncClosingLocked, setIsSyncClosingLocked] = useState(false)
   const syncModalRef = useRef<HTMLDivElement>(null)
 
   const group = groups.find((g) => g.id === groupId)
@@ -333,9 +334,13 @@ export function GroupDetail() {
           aria-modal="true"
           aria-label="Sincronitzar grup"
           tabIndex={-1}
-          onClick={() => setShowSyncModal(false)}
+          onClick={() => {
+            if (!isSyncClosingLocked) {
+              setShowSyncModal(false)
+            }
+          }}
           onKeyDown={(e) => {
-            if (e.key === 'Escape') {
+            if (e.key === 'Escape' && !isSyncClosingLocked) {
               setShowSyncModal(false)
             }
           }}
@@ -360,13 +365,14 @@ export function GroupDetail() {
                 size="icon"
                 onClick={() => setShowSyncModal(false)}
                 aria-label="Tancar sincronització"
+                disabled={isSyncClosingLocked}
               >
                 <X className="h-4 w-4" />
               </Button>
             </div>
 
             <Suspense fallback={<p className="text-sm text-muted-foreground">Carregant sincronització…</p>}>
-              <SyncPanel groupId={group.id} embedded />
+              <SyncPanel groupId={group.id} embedded onActiveStateChange={setIsSyncClosingLocked} />
             </Suspense>
           </div>
         </div>

--- a/src/features/groups/GroupDetail.tsx
+++ b/src/features/groups/GroupDetail.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useEffect, useRef, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { ArrowLeft, Plus, X, Pencil, Check, Settings, Archive, RefreshCw, Smartphone } from 'lucide-react'
+import { ArrowLeft, Plus, X, Pencil, Check, Settings, Archive, RefreshCw } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
@@ -142,6 +142,17 @@ export function GroupDetail() {
             <p className="text-sm text-muted-foreground truncate">{group.description}</p>
           )}
         </div>
+        {!isArchived && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setShowSyncModal(true)}
+            className="shrink-0"
+          >
+            <RefreshCw className="h-4 w-4 mr-1" />
+            Sync
+          </Button>
+        )}
         <Button
           variant="ghost"
           size="icon"
@@ -161,30 +172,6 @@ export function GroupDetail() {
         </div>
       )}
 
-      {!isArchived && (
-        <div className="mb-4 shrink-0 rounded-xl border border-indigo-200 bg-indigo-50/70 px-4 py-3 dark:border-indigo-900 dark:bg-indigo-950/40">
-          <div className="flex items-start justify-between gap-3">
-            <div className="min-w-0">
-              <div className="flex items-center gap-2 text-sm font-medium text-indigo-700 dark:text-indigo-300">
-                <Smartphone className="h-4 w-4" />
-                Continuïtat entre dispositius
-              </div>
-              <p className="mt-1 text-sm text-indigo-950/80 dark:text-indigo-100/80">
-                Posa aquest grup al dia en un altre mòbil o ordinador directament des d&apos;aquí. Si encara no tens contrasenya de grup, la pots definir abans de començar la sincronització.
-              </p>
-            </div>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setShowSyncModal(true)}
-              className="shrink-0 border-indigo-300 bg-white/80 text-indigo-700 hover:bg-white dark:border-indigo-800 dark:bg-indigo-950/60 dark:text-indigo-200 dark:hover:bg-indigo-950/80"
-            >
-              <RefreshCw className="h-4 w-4 mr-1" />
-              Obrir sync
-            </Button>
-          </div>
-        </div>
-      )}
 
       {/* Members section */}
       <div className="mb-6 shrink-0">

--- a/src/features/groups/GroupDetail.tsx
+++ b/src/features/groups/GroupDetail.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { ArrowLeft, Plus, X, Pencil, Check, Settings, Archive } from 'lucide-react'
+import { ArrowLeft, Plus, X, Pencil, Check, Settings, Archive, RefreshCw, Smartphone } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
@@ -148,6 +148,31 @@ export function GroupDetail() {
         <div className="mb-4 shrink-0 rounded-md bg-muted border border-border px-4 py-2 flex items-center gap-2 text-sm text-muted-foreground">
           <Archive className="h-4 w-4 shrink-0" />
           <span>Aquest grup és de només lectura. Desarxiva'l per poder fer canvis.</span>
+        </div>
+      )}
+
+      {!isArchived && (
+        <div className="mb-4 shrink-0 rounded-xl border border-indigo-200 bg-indigo-50/70 px-4 py-3 dark:border-indigo-900 dark:bg-indigo-950/40">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <div className="flex items-center gap-2 text-sm font-medium text-indigo-700 dark:text-indigo-300">
+                <Smartphone className="h-4 w-4" />
+                Continuïtat entre dispositius
+              </div>
+              <p className="mt-1 text-sm text-indigo-950/80 dark:text-indigo-100/80">
+                Si vols posar aquest grup al dia en un altre mòbil o ordinador, ves a <strong>Configuració → Sincronitzar grup</strong> i comparteix l&apos;enllaç de sync.
+              </p>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => navigate(`/group/${groupId}/settings`)}
+              className="shrink-0 border-indigo-300 bg-white/80 text-indigo-700 hover:bg-white dark:border-indigo-800 dark:bg-indigo-950/60 dark:text-indigo-200"
+            >
+              <RefreshCw className="h-4 w-4 mr-1" />
+              Sincronitzar
+            </Button>
+          </div>
         </div>
       )}
 

--- a/src/features/groups/GroupDetail.tsx
+++ b/src/features/groups/GroupDetail.tsx
@@ -368,7 +368,7 @@ export function GroupDetail() {
             </div>
 
             <Suspense fallback={<p className="text-sm text-muted-foreground">Carregant sincronització…</p>}>
-              <SyncPanel groupId={group.id} />
+              <SyncPanel groupId={group.id} embedded />
             </Suspense>
           </div>
         </div>

--- a/src/features/groups/GroupDetail.tsx
+++ b/src/features/groups/GroupDetail.tsx
@@ -144,13 +144,13 @@ export function GroupDetail() {
         </div>
         {!isArchived && (
           <Button
-            variant="outline"
-            size="sm"
+            variant="ghost"
+            size="icon"
             onClick={() => setShowSyncModal(true)}
-            className="shrink-0"
+            aria-label="Sincronitzar grup"
+            title="Sincronitzar grup"
           >
-            <RefreshCw className="h-4 w-4 mr-1" />
-            Sync
+            <RefreshCw className="h-5 w-5" />
           </Button>
         )}
         <Button
@@ -330,7 +330,7 @@ export function GroupDetail() {
       {showSyncModal && !isArchived && (
         <div
           ref={syncModalRef}
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+          className="fixed inset-0 z-50 flex items-end justify-center bg-black/50 sm:items-center"
           role="dialog"
           aria-modal="true"
           aria-label="Sincronitzar grup"
@@ -343,9 +343,12 @@ export function GroupDetail() {
           }}
         >
           <div
-            className="w-full max-w-xl max-h-[90vh] overflow-y-auto rounded-2xl bg-background p-4 shadow-xl"
+            className="w-full max-w-xl max-h-[85vh] overflow-y-auto rounded-t-3xl border bg-background p-4 shadow-xl sm:mb-4 sm:rounded-2xl"
             onClick={(e) => e.stopPropagation()}
           >
+            <div className="mb-3 flex justify-center sm:hidden">
+              <div className="h-1.5 w-12 rounded-full bg-muted-foreground/30" />
+            </div>
             <div className="mb-4 flex items-start justify-between gap-3">
               <div>
                 <h2 className="text-lg font-semibold">Sincronitzar grup</h2>

--- a/src/features/groups/GroupDetail.tsx
+++ b/src/features/groups/GroupDetail.tsx
@@ -170,14 +170,14 @@ export function GroupDetail() {
                 Continuïtat entre dispositius
               </div>
               <p className="mt-1 text-sm text-indigo-950/80 dark:text-indigo-100/80">
-                Posa aquest grup al dia en un altre mòbil o ordinador directament des d&apos;aquí. Si encara no tens contrasenya de grup, la pots definir abans de començar.
+                Posa aquest grup al dia en un altre mòbil o ordinador directament des d&apos;aquí. Si encara no tens contrasenya de grup, la pots definir abans de començar la sincronització.
               </p>
             </div>
             <Button
               variant="outline"
               size="sm"
               onClick={() => setShowSyncModal(true)}
-              className="shrink-0 border-indigo-300 bg-white/80 text-indigo-700 hover:bg-white dark:border-indigo-800 dark:bg-indigo-950/60 dark:text-indigo-200"
+              className="shrink-0 border-indigo-300 bg-white/80 text-indigo-700 hover:bg-white dark:border-indigo-800 dark:bg-indigo-950/60 dark:text-indigo-200 dark:hover:bg-indigo-950/80"
             >
               <RefreshCw className="h-4 w-4 mr-1" />
               Obrir sync

--- a/src/features/groups/GroupDetail.tsx
+++ b/src/features/groups/GroupDetail.tsx
@@ -4,7 +4,6 @@ import { ArrowLeft, Plus, X, Pencil, Check, Settings, Archive, RefreshCw } from 
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
-import { ThemeToggle } from '@/components/ThemeToggle'
 import { Badge } from '@/components/ui/badge'
 import { useStore } from '../../store'
 import { ExpenseList } from '../expenses/ExpenseList'
@@ -161,7 +160,6 @@ export function GroupDetail() {
         >
           <Settings className="h-5 w-5" />
         </Button>
-        <ThemeToggle />
       </div>
 
       {/* Archived banner */}

--- a/src/features/groups/SyncPanel.tsx
+++ b/src/features/groups/SyncPanel.tsx
@@ -185,6 +185,8 @@ export function SyncPanel({ groupId }: SyncPanelProps) {
 
   const isActive = sync.state !== 'idle' && sync.state !== 'error' && sync.state !== 'completed'
   const canStart = passphrase.length >= 4
+  const showSetupCopy = sync.state === 'idle'
+  const showCompactStatusDetails = sync.state !== 'idle' && !sync.error
 
   useEffect(() => {
     setPassphrase(rememberedPassphrase)
@@ -246,10 +248,12 @@ export function SyncPanel({ groupId }: SyncPanelProps) {
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
-        <p className="text-sm text-muted-foreground">
-          Posa aquest grup al dia entre dispositius amb una sola acció.
-          Si l'altre dispositiu és a punt, la sincronització començarà automàticament.
-        </p>
+        {showSetupCopy && (
+          <p className="text-sm text-muted-foreground">
+            Posa aquest grup al dia entre dispositius amb una sola acció.
+            Si l'altre dispositiu és a punt, la sincronització començarà automàticament.
+          </p>
+        )}
 
         {/* Passphrase input */}
         <div className="space-y-1.5">
@@ -326,7 +330,7 @@ export function SyncPanel({ groupId }: SyncPanelProps) {
 
             {/* Status message */}
             <div className="space-y-2">
-              <p className="text-sm font-medium">{sync.message}</p>
+              <p className="text-sm font-medium leading-snug">{sync.message}</p>
               {sync.error && (
                 <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
                   <div className="flex items-start gap-2">
@@ -338,10 +342,10 @@ export function SyncPanel({ groupId }: SyncPanelProps) {
                   </div>
                 </div>
               )}
-              {(sync.remotePeerIds.length > 0 || sync.lastAttemptAt || sync.lastSuccessAt) && (
-                <details className="rounded-md bg-muted/60 px-3 py-2 text-xs text-muted-foreground">
+              {showCompactStatusDetails && (sync.remotePeerIds.length > 0 || sync.lastAttemptAt || sync.lastSuccessAt) && (
+                <details className="rounded-md bg-muted/50 px-3 py-2 text-xs text-muted-foreground">
                   <summary className="cursor-pointer select-none font-medium text-foreground/80">
-                    Detalls de sincronització
+                    Detalls
                   </summary>
                   <div className="mt-2 space-y-1">
                     {sync.remotePeerIds.length > 0 && (
@@ -353,9 +357,6 @@ export function SyncPanel({ groupId }: SyncPanelProps) {
                     {sync.lastSuccessAt && (
                       <p>Última sincronització correcta: {formatSyncTimestamp(sync.lastSuccessAt)}</p>
                     )}
-                    {sync.autoRetryEnabled && (
-                      <p>Reintent automàtic actiu mentre aquest panell estigui obert</p>
-                    )}
                   </div>
                 </details>
               )}
@@ -363,18 +364,10 @@ export function SyncPanel({ groupId }: SyncPanelProps) {
 
             {/* Instructions for host + share link */}
             {mode === 'host' && sync.state === 'waiting-for-peer' && (
-              <div className="rounded-lg border bg-muted/50 p-4 text-sm space-y-3">
-                <div className="space-y-1">
-                  <p className="font-medium">Falta l'altre dispositiu</p>
-                  <p className="text-muted-foreground">
-                    Comparteix aquest enllaç i la sincronització començarà quan l'obrin.
-                  </p>
-                </div>
-                <ol className="space-y-1 text-muted-foreground">
-                  <li>1. Copia l'enllaç</li>
-                  <li>2. Obre'l a l'altre dispositiu</li>
-                  <li>3. Reparteix es connectarà i posarà el grup al dia</li>
-                </ol>
+              <div className="rounded-lg border bg-muted/40 p-3 text-sm space-y-2">
+                <p className="text-muted-foreground">
+                  Comparteix l'enllaç amb l'altre dispositiu i la sincronització començarà quan l'obrin.
+                </p>
                 <Button
                   variant="outline"
                   size="sm"
@@ -384,9 +377,6 @@ export function SyncPanel({ groupId }: SyncPanelProps) {
                   {sharedLinkStatus !== 'idle' ? <Check className="h-4 w-4 mr-2" /> : <Link2 className="h-4 w-4 mr-2" />}
                   {sharedLinkStatus === 'shared' ? 'Enllaç compartit!' : sharedLinkStatus === 'copied' ? 'Enllaç copiat!' : 'Compartir enllaç'}
                 </Button>
-                <p className="text-xs text-muted-foreground">
-                  Si prefereixes, també pots obrir Reparteix a l'altre dispositiu, entrar al mateix grup i prémer «Sincronitzar» amb la mateixa contrasenya.
-                </p>
               </div>
             )}
 

--- a/src/features/groups/SyncPanel.tsx
+++ b/src/features/groups/SyncPanel.tsx
@@ -153,14 +153,21 @@ function StateBadge({ state }: { state: string }) {
   const variants: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
     'idle': 'secondary',
     'initializing': 'outline',
-    'waiting-for-peer': 'outline',
+    'waiting-for-peer': 'secondary',
     'connecting': 'outline',
     'syncing': 'default',
     'completed': 'secondary',
     'error': 'destructive',
   }
 
-  return <Badge variant={variants[state] ?? 'secondary'}>{labels[state] ?? state}</Badge>
+  return (
+    <Badge
+      variant={variants[state] ?? 'secondary'}
+      className={state === 'waiting-for-peer' ? 'bg-emerald-50 text-emerald-700 border-emerald-200 hover:bg-emerald-50 dark:bg-emerald-950/40 dark:text-emerald-300 dark:border-emerald-900' : undefined}
+    >
+      {labels[state] ?? state}
+    </Badge>
+  )
 }
 
 export function SyncPanel({ groupId, embedded = false }: SyncPanelProps) {

--- a/src/features/groups/SyncPanel.tsx
+++ b/src/features/groups/SyncPanel.tsx
@@ -321,7 +321,7 @@ export function SyncPanel({ groupId, embedded = false }: SyncPanelProps) {
                   variant="ghost"
                   size="sm"
                   onClick={handleCopyPeerId}
-                  className="h-7 text-xs"
+                  className="h-7 px-2 text-xs text-muted-foreground"
                 >
                   {copied ? <Check className="h-3 w-3 mr-1" /> : <Copy className="h-3 w-3 mr-1" />}
                   {copied ? 'Copiat' : 'ID'}
@@ -370,7 +370,6 @@ export function SyncPanel({ groupId, embedded = false }: SyncPanelProps) {
                   Comparteix l'enllaç amb l'altre dispositiu i la sincronització començarà quan l'obrin.
                 </p>
                 <Button
-                  variant="outline"
                   size="sm"
                   onClick={handleCopySyncLink}
                   className="w-full"

--- a/src/features/groups/SyncPanel.tsx
+++ b/src/features/groups/SyncPanel.tsx
@@ -32,6 +32,7 @@ import type { SyncReport } from '@/domain/services/sync'
 interface SyncPanelProps {
   groupId: string
   embedded?: boolean
+  onActiveStateChange?: (active: boolean) => void
 }
 
 /**
@@ -163,14 +164,14 @@ function StateBadge({ state }: { state: string }) {
   return (
     <Badge
       variant={variants[state] ?? 'secondary'}
-      className={state === 'waiting-for-peer' ? 'bg-emerald-50 text-emerald-700 border-emerald-200 hover:bg-emerald-50 dark:bg-emerald-950/40 dark:text-emerald-300 dark:border-emerald-900' : undefined}
+      className={state === 'waiting-for-peer' ? 'bg-success/10 text-success border-success/20 hover:bg-success/10' : undefined}
     >
       {labels[state] ?? state}
     </Badge>
   )
 }
 
-export function SyncPanel({ groupId, embedded = false }: SyncPanelProps) {
+export function SyncPanel({ groupId, embedded = false, onActiveStateChange }: SyncPanelProps) {
   const group = useStore((state) => state.groups.find((item) => item.id === groupId))
   const updateGroup = useStore((state) => state.updateGroup)
   const rememberedPassphrase = useMemo(
@@ -203,6 +204,13 @@ export function SyncPanel({ groupId, embedded = false }: SyncPanelProps) {
   useEffect(() => {
     saveStoredSyncPassphrase(groupId, passphrase)
   }, [groupId, passphrase])
+
+  useEffect(() => {
+    onActiveStateChange?.(isActive)
+    return () => {
+      onActiveStateChange?.(false)
+    }
+  }, [isActive, onActiveStateChange])
 
   const persistPassphrase = async (value: string) => {
     const nextValue = value.trim()
@@ -248,7 +256,7 @@ export function SyncPanel({ groupId, embedded = false }: SyncPanelProps) {
   }
 
   const content = (
-      <div className={embedded ? 'space-y-4' : 'space-y-4'}>
+      <div className="space-y-4">
         {showSetupCopy && (
           <p className="text-sm text-muted-foreground">
             Posa aquest grup al dia entre dispositius amb una sola acció.

--- a/src/features/groups/SyncPanel.tsx
+++ b/src/features/groups/SyncPanel.tsx
@@ -31,6 +31,7 @@ import type { SyncReport } from '@/domain/services/sync'
 
 interface SyncPanelProps {
   groupId: string
+  embedded?: boolean
 }
 
 /**
@@ -162,7 +163,7 @@ function StateBadge({ state }: { state: string }) {
   return <Badge variant={variants[state] ?? 'secondary'}>{labels[state] ?? state}</Badge>
 }
 
-export function SyncPanel({ groupId }: SyncPanelProps) {
+export function SyncPanel({ groupId, embedded = false }: SyncPanelProps) {
   const group = useStore((state) => state.groups.find((item) => item.id === groupId))
   const updateGroup = useStore((state) => state.updateGroup)
   const rememberedPassphrase = useMemo(
@@ -239,15 +240,8 @@ export function SyncPanel({ groupId }: SyncPanelProps) {
     setTimeout(() => setSharedLinkStatus('idle'), 3000)
   }
 
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="text-base flex items-center gap-2">
-          <RefreshCw className="h-4 w-4" />
-          Sincronitzar grup
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-4">
+  const content = (
+      <div className={embedded ? 'space-y-4' : 'space-y-4'}>
         {showSetupCopy && (
           <p className="text-sm text-muted-foreground">
             Posa aquest grup al dia entre dispositius amb una sola acció.
@@ -415,7 +409,22 @@ export function SyncPanel({ groupId }: SyncPanelProps) {
             </div>
           </div>
         )}
-      </CardContent>
+      </div>
+  )
+
+  if (embedded) {
+    return content
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base flex items-center gap-2">
+          <RefreshCw className="h-4 w-4" />
+          Sincronitzar grup
+        </CardTitle>
+      </CardHeader>
+      <CardContent>{content}</CardContent>
     </Card>
   )
 }


### PR DESCRIPTION
## Què canvia
- mou la sincronització a una acció compacta de la capçalera del grup
- obre el flux real de sync en una mobile sheet/modal compacta
- fa servir `SyncPanel` en mode embegut dins la sheet
- compacta la UI de l'estat actiu perquè mostri menys informació redundant
- reforça l'estat `waiting-for-peer` com a estat llest/preparat
- evita tancar accidentalment la sheet mentre hi ha una sincronització activa

## Issue principal
Closes #117

## Context relacionat
- relacionat amb #116
- relacionat amb #135 pel moviment futur de preferències globals fora del detall de grup

## Aproximació UI/UX
Aquesta PR adopta un patró conegut i usable en producte mòbil:
- acció secundària i contextual a la toolbar/header
- contingut principal de la pantalla dedicat a les despeses
- flux acotat de sincronització dins una sheet/modal, sense navegar ni ocupar alçada persistent

La idea és que la sync sigui fàcil de trobar quan la necessites, però que no competeixi amb el cas d'ús principal del grup.

## Problema que resol
La sync ha de continuar accessible, però no ha de robar espai vertical ni pes visual a la vista del grup. En mòbil, el primer que s'ha de veure és el contingut econòmic del grup. A més, un tancament accidental de la sheet no ha d'interrompre silenciosament una sincronització activa.

## Scope
- `src/features/groups/GroupDetail.tsx`
- `src/features/groups/SyncPanel.tsx`

## Validació
- `npm run lint`
- `npm test`
- `npm run build`
