### PR TITLE
fix: keep group list cards aligned with long names on mobile

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -71,53 +71,34 @@ jobs:
           STAGING_TOKEN: ${{ secrets.STAGING_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          set -euo pipefail
-
           if [ -z "${STAGING_TOKEN}" ]; then
             echo "::warning::STAGING_TOKEN is not set. Skipping preview deployment. Add the secret in repository settings."
-            echo "deployed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           PR_DIR="pr-${PR_NUMBER}"
-          STAGING_DIR="/tmp/staging-${PR_NUMBER}"
-          rm -rf "${STAGING_DIR}"
-          git clone --depth 1 "https://x-access-token:${STAGING_TOKEN}@github.com/reparteix/staging.git" "${STAGING_DIR}"
+          git clone --depth 1 "https://x-access-token:${STAGING_TOKEN}@github.com/reparteix/staging.git" /tmp/staging
 
-          rm -rf "${STAGING_DIR}/${PR_DIR}"
-          cp -r dist "${STAGING_DIR}/${PR_DIR}"
-          touch "${STAGING_DIR}/.nojekyll"
+          # Remove previous preview if it exists, then copy new build
+          rm -rf "/tmp/staging/${PR_DIR}"
+          cp -r dist "/tmp/staging/${PR_DIR}"
 
-          cd "${STAGING_DIR}"
+          # Ensure .nojekyll exists at repo root
+          touch /tmp/staging/.nojekyll
+
+          cd /tmp/staging
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
           if git diff --cached --quiet; then
             echo "No changes to commit"
-            echo "deployed=true" >> "$GITHUB_OUTPUT"
-            exit 0
+          else
+            git commit -m "deploy: update preview for PR #${PR_NUMBER}"
+            git push origin main
           fi
-
-          git commit -m "deploy: update preview for PR #${PR_NUMBER}"
-          git push origin main
-
-          REMOTE_HEAD=$(git ls-remote origin refs/heads/main | cut -f1)
-          LOCAL_HEAD=$(git rev-parse HEAD)
-
-          if [ -z "${REMOTE_HEAD}" ]; then
-            echo "::error::Could not resolve remote staging main after push"
-            exit 1
-          fi
-
-          if [ "${REMOTE_HEAD}" != "${LOCAL_HEAD}" ]; then
-            echo "::error::Staging main is not yet at pushed commit ${LOCAL_HEAD} (remote: ${REMOTE_HEAD})"
-            exit 1
-          fi
-
-          echo "deployed=true" >> "$GITHUB_OUTPUT"
 
       - name: Set deployment status to success
-        if: success() && steps.deploy.outputs.deployed == 'true'
+        if: success()
         uses: actions/github-script@v8
         with:
           script: |
@@ -146,7 +127,6 @@ jobs:
             });
 
       - name: Comment on PR with preview URL
-        if: success() && steps.deploy.outputs.deployed == 'true'
         uses: actions/github-script@v8
         with:
           script: |

--- a/src/features/groups/GroupDetail.tsx
+++ b/src/features/groups/GroupDetail.tsx
@@ -99,6 +99,12 @@ export function GroupDetail() {
     setEditingName('')
   }
 
+  useEffect(() => {
+    if (showSyncModal) {
+      syncModalRef.current?.focus()
+    }
+  }, [showSyncModal])
+
   if (!group) {
     return (
       <div className="max-w-2xl mx-auto p-4">
@@ -108,12 +114,6 @@ export function GroupDetail() {
   }
 
   const activeMembers = group.members.filter((m) => !m.deleted)
-
-  useEffect(() => {
-    if (showSyncModal) {
-      syncModalRef.current?.focus()
-    }
-  }, [showSyncModal])
 
   return (
     <div className="fixed inset-0 bg-background overflow-hidden flex flex-col">

--- a/src/features/groups/GroupDetail.tsx
+++ b/src/features/groups/GroupDetail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { lazy, Suspense, useEffect, useRef, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { ArrowLeft, Plus, X, Pencil, Check, Settings, Archive, RefreshCw, Smartphone } from 'lucide-react'
 import { Button } from '@/components/ui/button'
@@ -22,6 +22,8 @@ import {
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog'
 
+const SyncPanel = lazy(() => import('./SyncPanel').then((m) => ({ default: m.SyncPanel })))
+
 export function GroupDetail() {
   const { groupId } = useParams<{ groupId: string }>()
   const navigate = useNavigate()
@@ -39,6 +41,8 @@ export function GroupDetail() {
   const [showAddMember, setShowAddMember] = useState(false)
   const [editingMemberId, setEditingMemberId] = useState<string | null>(null)
   const [editingName, setEditingName] = useState('')
+  const [showSyncModal, setShowSyncModal] = useState(false)
+  const syncModalRef = useRef<HTMLDivElement>(null)
 
   const group = groups.find((g) => g.id === groupId)
   const isArchived = group?.archived ?? false
@@ -105,6 +109,12 @@ export function GroupDetail() {
 
   const activeMembers = group.members.filter((m) => !m.deleted)
 
+  useEffect(() => {
+    if (showSyncModal) {
+      syncModalRef.current?.focus()
+    }
+  }, [showSyncModal])
+
   return (
     <div className="fixed inset-0 bg-background overflow-hidden flex flex-col">
       <div className="flex-1 max-w-2xl mx-auto w-full flex flex-col min-h-0 px-4">
@@ -160,17 +170,17 @@ export function GroupDetail() {
                 Continuïtat entre dispositius
               </div>
               <p className="mt-1 text-sm text-indigo-950/80 dark:text-indigo-100/80">
-                Si vols posar aquest grup al dia en un altre mòbil o ordinador, ves a <strong>Configuració → Sincronitzar grup</strong> i comparteix l&apos;enllaç de sync.
+                Posa aquest grup al dia en un altre mòbil o ordinador directament des d&apos;aquí. Si encara no tens contrasenya de grup, la pots definir abans de començar.
               </p>
             </div>
             <Button
               variant="outline"
               size="sm"
-              onClick={() => navigate(`/group/${groupId}/settings`)}
+              onClick={() => setShowSyncModal(true)}
               className="shrink-0 border-indigo-300 bg-white/80 text-indigo-700 hover:bg-white dark:border-indigo-800 dark:bg-indigo-950/60 dark:text-indigo-200"
             >
               <RefreshCw className="h-4 w-4 mr-1" />
-              Sincronitzar
+              Obrir sync
             </Button>
           </div>
         </div>
@@ -329,6 +339,50 @@ export function GroupDetail() {
         </TabsContent>
       </Tabs>
       </div>
+
+      {showSyncModal && !isArchived && (
+        <div
+          ref={syncModalRef}
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Sincronitzar grup"
+          tabIndex={-1}
+          onClick={() => setShowSyncModal(false)}
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') {
+              setShowSyncModal(false)
+            }
+          }}
+        >
+          <div
+            className="w-full max-w-xl max-h-[90vh] overflow-y-auto rounded-2xl bg-background p-4 shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="mb-4 flex items-start justify-between gap-3">
+              <div>
+                <h2 className="text-lg font-semibold">Sincronitzar grup</h2>
+                <p className="text-sm text-muted-foreground">
+                  Comparteix el grup amb un altre dispositiu sense sortir d&apos;aquesta vista.
+                </p>
+              </div>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                onClick={() => setShowSyncModal(false)}
+                aria-label="Tancar sincronització"
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+
+            <Suspense fallback={<p className="text-sm text-muted-foreground">Carregant sincronització…</p>}>
+              <SyncPanel groupId={group.id} />
+            </Suspense>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/features/groups/GroupDetail.tsx
+++ b/src/features/groups/GroupDetail.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useEffect, useRef, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { ArrowLeft, Plus, X, Pencil, Check, Settings, Archive, RefreshCw, Smartphone } from 'lucide-react'
+import { ArrowLeft, Plus, X, Pencil, Check, Settings, Archive, RefreshCw } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
@@ -142,6 +142,17 @@ export function GroupDetail() {
             <p className="text-sm text-muted-foreground truncate">{group.description}</p>
           )}
         </div>
+        {!isArchived && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setShowSyncModal(true)}
+            className="shrink-0"
+          >
+            <RefreshCw className="h-4 w-4 mr-1" />
+            Sync
+          </Button>
+        )}
         <Button
           variant="ghost"
           size="icon"
@@ -161,30 +172,6 @@ export function GroupDetail() {
         </div>
       )}
 
-      {!isArchived && (
-        <div className="mb-4 shrink-0 rounded-xl border border-indigo-200 bg-indigo-50/70 px-4 py-3 dark:border-indigo-900 dark:bg-indigo-950/40">
-          <div className="flex items-start justify-between gap-3">
-            <div className="min-w-0">
-              <div className="flex items-center gap-2 text-sm font-medium text-indigo-700 dark:text-indigo-300">
-                <Smartphone className="h-4 w-4" />
-                Continuïtat entre dispositius
-              </div>
-              <p className="mt-1 text-sm text-indigo-950/80 dark:text-indigo-100/80">
-                Posa aquest grup al dia en un altre mòbil o ordinador directament des d&apos;aquí. Si encara no tens contrasenya de grup, la pots definir abans de començar la sincronització.
-              </p>
-            </div>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setShowSyncModal(true)}
-              className="shrink-0 border-indigo-300 bg-white/80 text-indigo-700 hover:bg-white dark:border-indigo-800 dark:bg-indigo-950/60 dark:text-indigo-200 dark:hover:bg-indigo-950/80"
-            >
-              <RefreshCw className="h-4 w-4 mr-1" />
-              Obrir sync
-            </Button>
-          </div>
-        </div>
-      )}
 
       {/* Members section */}
       <div className="mb-6 shrink-0">

--- a/src/features/groups/GroupDetail.tsx
+++ b/src/features/groups/GroupDetail.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { ArrowLeft, Plus, X, Pencil, Check, Settings, Archive } from 'lucide-react'
+import { ArrowLeft, Plus, X, Pencil, Check, Settings, Archive, RefreshCw, Smartphone } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
@@ -148,6 +148,31 @@ export function GroupDetail() {
         <div className="mb-4 shrink-0 rounded-md bg-muted border border-border px-4 py-2 flex items-center gap-2 text-sm text-muted-foreground">
           <Archive className="h-4 w-4 shrink-0" />
           <span>Aquest grup és de només lectura. Desarxiva'l per poder fer canvis.</span>
+        </div>
+      )}
+
+      {!isArchived && (
+        <div className="mb-4 shrink-0 rounded-xl border border-indigo-200 bg-indigo-50/70 px-4 py-3 dark:border-indigo-900 dark:bg-indigo-950/40">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <div className="flex items-center gap-2 text-sm font-medium text-indigo-700 dark:text-indigo-300">
+                <Smartphone className="h-4 w-4" />
+                Continuïtat entre dispositius
+              </div>
+              <p className="mt-1 text-sm text-indigo-950/80 dark:text-indigo-100/80">
+                Si vols posar aquest grup al dia en un altre mòbil o ordinador, ves a <strong>Configuració → Sincronitzar grup</strong> i comparteix l&apos;enllaç de sync.
+              </p>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => navigate(`/group/${groupId}/settings`)}
+              className="shrink-0 border-indigo-300 bg-white/80 text-indigo-700 hover:bg-white dark:border-indigo-800 dark:bg-indigo-950/60 dark:text-indigo-200"
+            >
+              <RefreshCw className="h-4 w-4 mr-1" />
+              Sincronitzar
+            </Button>
+          </div>
         </div>
       )}
 

--- a/src/features/groups/GroupDetail.tsx
+++ b/src/features/groups/GroupDetail.tsx
@@ -144,13 +144,13 @@ export function GroupDetail() {
         </div>
         {!isArchived && (
           <Button
-            variant="outline"
-            size="sm"
+            variant="ghost"
+            size="icon"
             onClick={() => setShowSyncModal(true)}
-            className="shrink-0"
+            aria-label="Sincronitzar grup"
+            title="Sincronitzar grup"
           >
-            <RefreshCw className="h-4 w-4 mr-1" />
-            Sync
+            <RefreshCw className="h-5 w-5" />
           </Button>
         )}
         <Button
@@ -330,7 +330,7 @@ export function GroupDetail() {
       {showSyncModal && !isArchived && (
         <div
           ref={syncModalRef}
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+          className="fixed inset-0 z-50 flex items-end justify-center bg-black/50 sm:items-center"
           role="dialog"
           aria-modal="true"
           aria-label="Sincronitzar grup"
@@ -343,9 +343,12 @@ export function GroupDetail() {
           }}
         >
           <div
-            className="w-full max-w-xl max-h-[90vh] overflow-y-auto rounded-2xl bg-background p-4 shadow-xl"
+            className="w-full max-w-xl max-h-[85vh] overflow-y-auto rounded-t-3xl border bg-background p-4 shadow-xl sm:mb-4 sm:rounded-2xl"
             onClick={(e) => e.stopPropagation()}
           >
+            <div className="mb-3 flex justify-center sm:hidden">
+              <div className="h-1.5 w-12 rounded-full bg-muted-foreground/30" />
+            </div>
             <div className="mb-4 flex items-start justify-between gap-3">
               <div>
                 <h2 className="text-lg font-semibold">Sincronitzar grup</h2>

--- a/src/features/groups/GroupDetail.tsx
+++ b/src/features/groups/GroupDetail.tsx
@@ -170,14 +170,14 @@ export function GroupDetail() {
                 Continuïtat entre dispositius
               </div>
               <p className="mt-1 text-sm text-indigo-950/80 dark:text-indigo-100/80">
-                Posa aquest grup al dia en un altre mòbil o ordinador directament des d&apos;aquí. Si encara no tens contrasenya de grup, la pots definir abans de començar.
+                Posa aquest grup al dia en un altre mòbil o ordinador directament des d&apos;aquí. Si encara no tens contrasenya de grup, la pots definir abans de començar la sincronització.
               </p>
             </div>
             <Button
               variant="outline"
               size="sm"
               onClick={() => setShowSyncModal(true)}
-              className="shrink-0 border-indigo-300 bg-white/80 text-indigo-700 hover:bg-white dark:border-indigo-800 dark:bg-indigo-950/60 dark:text-indigo-200"
+              className="shrink-0 border-indigo-300 bg-white/80 text-indigo-700 hover:bg-white dark:border-indigo-800 dark:bg-indigo-950/60 dark:text-indigo-200 dark:hover:bg-indigo-950/80"
             >
               <RefreshCw className="h-4 w-4 mr-1" />
               Obrir sync

--- a/src/features/groups/GroupList.tsx
+++ b/src/features/groups/GroupList.tsx
@@ -94,10 +94,10 @@ export function GroupList() {
       key={group.id}
       className={`hover:shadow-md transition-shadow duration-150 ${group.archived ? 'opacity-70' : ''}`}
     >
-      <div className="flex items-center p-4">
+      <div className="flex items-stretch p-4 gap-2">
         <button
           onClick={() => navigate(`/group/${group.id}`)}
-          className="flex-1 text-left flex items-center gap-3"
+          className="min-w-0 flex-1 text-left flex items-center gap-3"
         >
           <div className="flex h-10 w-10 items-center justify-center rounded-full bg-indigo-50 dark:bg-indigo-950 text-xl shrink-0">
             {group.icon ? (
@@ -106,37 +106,37 @@ export function GroupList() {
               <Users className="h-5 w-5 text-indigo-400 dark:text-indigo-300" />
             )}
           </div>
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2">
-              <h3 className="font-semibold truncate">{group.name}</h3>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-start gap-2">
+              <h3 className="font-semibold leading-tight break-words line-clamp-2">{group.name}</h3>
               {group.archived && (
                 <Badge variant="outline" className="text-xs text-muted-foreground shrink-0">
                   Arxivat
                 </Badge>
               )}
             </div>
-            <p className="text-sm text-muted-foreground">
+            <p className="mt-1 text-sm text-muted-foreground">
               {group.members.filter((m) => !m.deleted).length} membres
             </p>
           </div>
-          <div className="flex flex-col items-end gap-0.5 mr-1">
+          <div className="shrink-0 flex flex-col items-end gap-1 text-right">
             <Badge variant="secondary">{group.currency}</Badge>
             {(groupTotals[group.id] ?? 0) > 0 && (
-              <span className="text-xs text-muted-foreground">
+              <span className="text-xs text-muted-foreground max-w-[88px] break-words">
                 {groupTotals[group.id].toFixed(2)}&nbsp;{group.currency}
               </span>
             )}
           </div>
-          <ChevronRight className="h-4 w-4 text-muted-foreground ml-1" />
+          <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
         </button>
-        <Separator orientation="vertical" className="mx-2 h-8" />
+        <Separator orientation="vertical" className="h-auto self-stretch" />
         <AlertDialog>
           <AlertDialogTrigger asChild>
             <Button
               variant="ghost"
               size="icon"
               aria-label="Eliminar grup"
-              className="text-muted-foreground hover:text-destructive"
+              className="shrink-0 self-center text-muted-foreground hover:text-destructive"
             >
               <Trash2 className="h-4 w-4" />
             </Button>


### PR DESCRIPTION
## Què canvia
- evita que els noms de grup massa llargs desquadrin la card en mòbil
- limita el títol a dues línies i permet trencament controlat
- manté import, moneda i accions alineades dins la card

## Issue principal
Closes #132

## Problema que resol
Amb noms de grup llargs, la card empenyia les accions cap a fora i es trencava el layout en pantalles estretes.

## Aproximació
- columna central realment flexible amb `min-w-0`
- metadata dreta com a bloc `shrink-0`
- títol a 2 línies en lloc d'una sola línia rígida
- accions separades del contingut principal però dins la card

## Validació
- `npm run lint`
- `npm test`
- `npm run build`
