### PR TITLE
feat: add preferences page for theme and sync settings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { useFileHandler } from './hooks/useFileHandler'
 const GroupList = lazy(() => import('./features/groups/GroupList').then((m) => ({ default: m.GroupList })))
 const GroupDetail = lazy(() => import('./features/groups/GroupDetail').then((m) => ({ default: m.GroupDetail })))
 const GroupSettings = lazy(() => import('./features/groups/GroupSettings').then((m) => ({ default: m.GroupSettings })))
+const Preferences = lazy(() => import('./features/groups/Preferences').then((m) => ({ default: m.Preferences })))
 const ImportFromUrl = lazy(() => import('./features/groups/ImportFromUrl').then((m) => ({ default: m.ImportFromUrl })))
 const OnboardingWizard = lazy(() => import('./features/groups/OnboardingWizard').then((m) => ({ default: m.OnboardingWizard })))
 const SyncFromUrl = lazy(() => import('./features/groups/SyncFromUrl').then((m) => ({ default: m.SyncFromUrl })))
@@ -52,6 +53,7 @@ function App() {
             <Route path="/onboarding" element={<OnboardingWizard />} />
             <Route path="/group/:groupId" element={<GroupDetail />} />
             <Route path="/group/:groupId/settings" element={<GroupSettings />} />
+            <Route path="/preferences" element={<Preferences />} />
             <Route path="/import" element={<ImportFromUrl />} />
             <Route path="/import/shared" element={<ShareTargetImport />} />
             <Route path="/sync" element={<SyncFromUrl />} />

--- a/src/features/groups/GroupList.tsx
+++ b/src/features/groups/GroupList.tsx
@@ -1,9 +1,8 @@
 import { useEffect, useRef, useState } from 'react'
 import { useStore } from '../../store'
 import { useNavigate } from 'react-router-dom'
-import { Plus, Trash2, Users, ChevronRight, Upload, Archive, ChevronDown } from 'lucide-react'
+import { Plus, Trash2, Users, ChevronRight, Upload, Archive, ChevronDown, Settings } from 'lucide-react'
 import { ONBOARDING_COMPLETED_KEY } from './OnboardingWizard'
-import { ThemeToggle } from '@/components/ThemeToggle'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
@@ -168,14 +167,22 @@ export function GroupList() {
       {/* Hero / Header */}
       <div className="bg-gradient-to-br from-indigo-600 to-indigo-800 dark:from-indigo-800 dark:to-indigo-950 text-white px-4 pt-10 pb-12">
         <div className="max-w-2xl mx-auto">
-          <div className="flex items-start justify-between">
+          <div className="flex items-start justify-between gap-3">
             <div>
               <h1 className="text-4xl font-bold tracking-tight mb-2">🧾 Reparteix</h1>
               <p className="text-indigo-200 text-base">
                 Gestiona despeses compartides de forma senzilla, local i privada.
               </p>
             </div>
-            <ThemeToggle />
+            <Button
+              variant="secondary"
+              size="icon"
+              onClick={() => navigate('/preferences')}
+              aria-label="Preferències"
+              className="shrink-0 bg-white/10 text-white hover:bg-white/20 dark:bg-white/10 dark:hover:bg-white/20"
+            >
+              <Settings className="h-4 w-4" />
+            </Button>
           </div>
         </div>
       </div>

--- a/src/features/groups/Preferences.tsx
+++ b/src/features/groups/Preferences.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { ArrowLeft, Monitor, Moon, Settings2, Sun, Wifi } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
@@ -63,18 +63,37 @@ function ThemePreferenceCard() {
 function SyncPreferencesCard() {
   const [draft, setDraft] = useState<SyncPreferencesDraft>(() => loadSyncPreferencesDraft())
   const [status, setStatus] = useState<'idle' | 'saved' | 'reset'>('idle')
+  const statusTimeoutRef = useRef<number | null>(null)
 
   useEffect(() => {
     saveSyncPreferencesDraft(draft)
   }, [draft])
 
+  useEffect(() => {
+    return () => {
+      if (statusTimeoutRef.current !== null) {
+        window.clearTimeout(statusTimeoutRef.current)
+      }
+    }
+  }, [])
+
   const preview = useMemo(() => draftToSyncConfigOverrides(draft), [draft])
+
+  const scheduleStatusReset = () => {
+    if (statusTimeoutRef.current !== null) {
+      window.clearTimeout(statusTimeoutRef.current)
+    }
+
+    statusTimeoutRef.current = window.setTimeout(() => {
+      setStatus('idle')
+      statusTimeoutRef.current = null
+    }, 2000)
+  }
 
   const setField = <K extends keyof SyncPreferencesDraft>(key: K, value: SyncPreferencesDraft[K]) => {
     setDraft((current) => ({ ...current, [key]: value }))
     setStatus('saved')
-    window.clearTimeout((setField as unknown as { timeout?: number }).timeout)
-    ;(setField as unknown as { timeout?: number }).timeout = window.setTimeout(() => setStatus('idle'), 2000)
+    scheduleStatusReset()
   }
 
   const handleReset = () => {
@@ -83,7 +102,7 @@ function SyncPreferencesCard() {
     clearSyncPreferencesDraft()
     saveSyncPreferencesDraft(next)
     setStatus('reset')
-    window.setTimeout(() => setStatus('idle'), 2000)
+    scheduleStatusReset()
   }
 
   return (

--- a/src/features/groups/Preferences.tsx
+++ b/src/features/groups/Preferences.tsx
@@ -1,0 +1,242 @@
+import { useEffect, useMemo, useState } from 'react'
+import { ArrowLeft, Monitor, Moon, Settings2, Sun, Wifi } from 'lucide-react'
+import { useNavigate } from 'react-router-dom'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Separator } from '@/components/ui/separator'
+import { Textarea } from '@/components/ui/textarea'
+import { useTheme } from '@/hooks/useTheme'
+import {
+  clearSyncPreferencesDraft,
+  draftToSyncConfigOverrides,
+  getDefaultSyncPreferencesDraft,
+  loadSyncPreferencesDraft,
+  saveSyncPreferencesDraft,
+  type SyncPreferencesDraft,
+} from '@/lib/sync-preferences'
+
+const themeOptions = [
+  { value: 'light' as const, label: 'Clar', icon: Sun },
+  { value: 'dark' as const, label: 'Fosc', icon: Moon },
+  { value: 'system' as const, label: 'Sistema', icon: Monitor },
+]
+
+function ThemePreferenceCard() {
+  const { theme, resolvedTheme, setTheme } = useTheme()
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Aparença</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+          {themeOptions.map((option) => {
+            const Icon = option.icon
+            const active = theme === option.value
+
+            return (
+              <Button
+                key={option.value}
+                type="button"
+                variant={active ? 'default' : 'outline'}
+                className="justify-start gap-2"
+                onClick={() => setTheme(option.value)}
+              >
+                <Icon className="h-4 w-4" />
+                {option.label}
+              </Button>
+            )
+          })}
+        </div>
+        <p className="text-sm text-muted-foreground">
+          Tema actiu: <strong>{themeOptions.find((option) => option.value === theme)?.label}</strong>
+          {theme === 'system' ? `, resolt ara com a ${resolvedTheme === 'dark' ? 'fosc' : 'clar'}` : ''}.
+        </p>
+      </CardContent>
+    </Card>
+  )
+}
+
+function SyncPreferencesCard() {
+  const [draft, setDraft] = useState<SyncPreferencesDraft>(() => loadSyncPreferencesDraft())
+  const [status, setStatus] = useState<'idle' | 'saved' | 'reset'>('idle')
+
+  useEffect(() => {
+    saveSyncPreferencesDraft(draft)
+  }, [draft])
+
+  const preview = useMemo(() => draftToSyncConfigOverrides(draft), [draft])
+
+  const setField = <K extends keyof SyncPreferencesDraft>(key: K, value: SyncPreferencesDraft[K]) => {
+    setDraft((current) => ({ ...current, [key]: value }))
+    setStatus('saved')
+    window.clearTimeout((setField as unknown as { timeout?: number }).timeout)
+    ;(setField as unknown as { timeout?: number }).timeout = window.setTimeout(() => setStatus('idle'), 2000)
+  }
+
+  const handleReset = () => {
+    const next = getDefaultSyncPreferencesDraft()
+    setDraft(next)
+    clearSyncPreferencesDraft()
+    saveSyncPreferencesDraft(next)
+    setStatus('reset')
+    window.setTimeout(() => setStatus('idle'), 2000)
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Sincronització avançada</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        <p className="text-sm text-muted-foreground">
+          Configura el servidor de signaling i els servidors STUN si vols fer servir infraestructura pròpia o provar un entorn diferent.
+        </p>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="peer-host">PeerJS host</Label>
+          <Input
+            id="peer-host"
+            value={draft.peerJsHost}
+            onChange={(e) => setField('peerJsHost', e.target.value)}
+            placeholder="0.peerjs.com"
+          />
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="peer-port">PeerJS port</Label>
+            <Input
+              id="peer-port"
+              inputMode="numeric"
+              value={draft.peerJsPort}
+              onChange={(e) => setField('peerJsPort', e.target.value)}
+              placeholder="443"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="peer-path">PeerJS path</Label>
+            <Input
+              id="peer-path"
+              value={draft.peerJsPath}
+              onChange={(e) => setField('peerJsPath', e.target.value)}
+              placeholder="/"
+            />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <Label>Connexió segura</Label>
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              variant={draft.peerJsSecure ? 'default' : 'outline'}
+              onClick={() => setField('peerJsSecure', true)}
+            >
+              HTTPS
+            </Button>
+            <Button
+              type="button"
+              variant={!draft.peerJsSecure ? 'default' : 'outline'}
+              onClick={() => setField('peerJsSecure', false)}
+            >
+              HTTP
+            </Button>
+          </div>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="stun-urls">Servidors STUN</Label>
+          <Textarea
+            id="stun-urls"
+            value={draft.stunUrls}
+            onChange={(e) => setField('stunUrls', e.target.value)}
+            rows={5}
+            placeholder="stun:stun.l.google.com:19302&#10;stun:stun1.l.google.com:19302"
+          />
+          <p className="text-xs text-muted-foreground">Un URL per línia. El suport TURN queda pendent per una iteració posterior.</p>
+        </div>
+
+        <Separator />
+
+        <div className="rounded-lg border bg-muted/30 p-3 text-sm space-y-1">
+          <p className="font-medium">Preview efectiva</p>
+          <p className="text-muted-foreground">
+            {preview.peerJs?.secure ? 'https' : 'http'}://{preview.peerJs?.host}:{preview.peerJs?.port}{preview.peerJs?.path}
+          </p>
+          <p className="text-muted-foreground">
+            {preview.iceServers?.length ?? 0} servidor{(preview.iceServers?.length ?? 0) === 1 ? '' : 's'} ICE configurat{(preview.iceServers?.length ?? 0) === 1 ? '' : 's'}.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <Button type="button" variant="outline" onClick={handleReset}>
+            Restaurar valors per defecte
+          </Button>
+          {status === 'saved' && <p className="text-sm text-success self-center">Preferències desades.</p>}
+          {status === 'reset' && <p className="text-sm text-success self-center">Valors per defecte restaurats.</p>}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+export function Preferences() {
+  const navigate = useNavigate()
+
+  return (
+    <div className="max-w-2xl mx-auto p-4 space-y-6">
+      <div className="flex items-center gap-3">
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={() => navigate('/')}
+          aria-label="Tornar"
+        >
+          <ArrowLeft className="h-5 w-5" />
+        </Button>
+        <div>
+          <h1 className="text-2xl font-bold">Preferències</h1>
+          <p className="text-sm text-muted-foreground">Aparença i configuració avançada del dispositiu.</p>
+        </div>
+      </div>
+
+      <Card>
+        <CardContent className="pt-6">
+          <div className="flex items-start gap-3">
+            <div className="rounded-full bg-indigo-50 p-2 text-indigo-600 dark:bg-indigo-950 dark:text-indigo-300">
+              <Settings2 className="h-5 w-5" />
+            </div>
+            <div className="space-y-1">
+              <p className="font-medium">Preferències globals</p>
+              <p className="text-sm text-muted-foreground">
+                Aquestes opcions s'apliquen al dispositiu actual. No canvien les dades dels grups ni es comparteixen amb altres persones.
+              </p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <ThemePreferenceCard />
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base flex items-center gap-2">
+            <Wifi className="h-4 w-4" />
+            P2P i connectivitat
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            Si no toques res, Reparteix continua amb la configuració pública per defecte. Aquesta secció és per desplegaments propis, proves o entorns més avançats.
+          </p>
+        </CardContent>
+      </Card>
+
+      <SyncPreferencesCard />
+    </div>
+  )
+}

--- a/src/hooks/useSync.ts
+++ b/src/hooks/useSync.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import { createSyncSession, type SyncSessionStatus, type SyncSessionState } from '../infra/sync/sync-session'
 import type { SyncConfigOverrides } from '../infra/sync/config'
 import type { SyncReport } from '../domain/services/sync'
+import { loadSyncConfigOverrides } from '../lib/sync-preferences'
 
 export interface UseSyncOptions {
   groupId: string
@@ -81,7 +82,17 @@ export function useSync({
 
   const ensureSession = useCallback(() => {
     if (!sessionRef.current) {
-      const session = createSyncSession(groupId, passphrase, configOverrides)
+      const storedConfig = loadSyncConfigOverrides()
+      const effectiveConfig = configOverrides ? {
+        ...storedConfig,
+        ...configOverrides,
+        peerJs: {
+          ...storedConfig.peerJs,
+          ...configOverrides.peerJs,
+        },
+        iceServers: configOverrides.iceServers ?? storedConfig.iceServers,
+      } : storedConfig
+      const session = createSyncSession(groupId, passphrase, effectiveConfig)
       session.subscribe(setStatus)
       sessionRef.current = session
     }

--- a/src/lib/sync-preferences.ts
+++ b/src/lib/sync-preferences.ts
@@ -1,0 +1,90 @@
+import { createSyncConfig, DEFAULT_SYNC_CONFIG, type SyncConfigOverrides } from '@/infra/sync/config'
+
+const STORAGE_KEY = 'reparteix-sync-preferences'
+
+export interface SyncPreferencesDraft {
+  peerJsHost: string
+  peerJsPort: string
+  peerJsPath: string
+  peerJsSecure: boolean
+  stunUrls: string
+}
+
+function normalizePath(path: string): string {
+  const trimmed = path.trim()
+  if (!trimmed) return '/'
+  return trimmed.startsWith('/') ? trimmed : `/${trimmed}`
+}
+
+export function getDefaultSyncPreferencesDraft(): SyncPreferencesDraft {
+  return {
+    peerJsHost: DEFAULT_SYNC_CONFIG.peerJs.host,
+    peerJsPort: String(DEFAULT_SYNC_CONFIG.peerJs.port),
+    peerJsPath: DEFAULT_SYNC_CONFIG.peerJs.path,
+    peerJsSecure: DEFAULT_SYNC_CONFIG.peerJs.secure,
+    stunUrls: DEFAULT_SYNC_CONFIG.iceServers
+      .map((server) => server.urls)
+      .flatMap((urls) => Array.isArray(urls) ? urls : [urls])
+      .join('\n'),
+  }
+}
+
+export function loadSyncPreferencesDraft(): SyncPreferencesDraft {
+  const fallback = getDefaultSyncPreferencesDraft()
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    if (!raw) return fallback
+
+    const parsed = JSON.parse(raw) as Partial<SyncPreferencesDraft>
+    return {
+      peerJsHost: typeof parsed.peerJsHost === 'string' ? parsed.peerJsHost : fallback.peerJsHost,
+      peerJsPort: typeof parsed.peerJsPort === 'string' ? parsed.peerJsPort : fallback.peerJsPort,
+      peerJsPath: typeof parsed.peerJsPath === 'string' ? parsed.peerJsPath : fallback.peerJsPath,
+      peerJsSecure: typeof parsed.peerJsSecure === 'boolean' ? parsed.peerJsSecure : fallback.peerJsSecure,
+      stunUrls: typeof parsed.stunUrls === 'string' ? parsed.stunUrls : fallback.stunUrls,
+    }
+  } catch {
+    return fallback
+  }
+}
+
+export function saveSyncPreferencesDraft(draft: SyncPreferencesDraft) {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(draft))
+  } catch {
+    /* localStorage unavailable */
+  }
+}
+
+export function clearSyncPreferencesDraft() {
+  try {
+    window.localStorage.removeItem(STORAGE_KEY)
+  } catch {
+    /* localStorage unavailable */
+  }
+}
+
+export function draftToSyncConfigOverrides(draft: SyncPreferencesDraft): SyncConfigOverrides {
+  const fallback = createSyncConfig()
+  const port = Number.parseInt(draft.peerJsPort.trim(), 10)
+  const iceServers = draft.stunUrls
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((url) => ({ urls: url }))
+
+  return {
+    peerJs: {
+      host: draft.peerJsHost.trim() || fallback.peerJs.host,
+      port: Number.isFinite(port) && port > 0 ? port : fallback.peerJs.port,
+      path: normalizePath(draft.peerJsPath),
+      secure: draft.peerJsSecure,
+    },
+    iceServers: iceServers.length > 0 ? iceServers : fallback.iceServers,
+  }
+}
+
+export function loadSyncConfigOverrides(): SyncConfigOverrides {
+  return draftToSyncConfigOverrides(loadSyncPreferencesDraft())
+}


### PR DESCRIPTION
## Què canvia
- afegeix una pàgina global de `Preferències`
- mou el control d'aparença fora de la home cap a aquesta pàgina
- afegeix configuració avançada de sincronització per PeerJS i STUN
- persisteix aquestes preferències localment al dispositiu
- aplica els overrides guardats al flux real de sync

## Issue principal
Closes #135

## Problema que resol
Fins ara les preferències globals no tenien un lloc propi i el control de tema vivia a la home, ocupant espai de capçalera. A més, la configuració avançada de `signaling` i `STUN` no era accessible des de la UI, tot i que la infraestructura ja suportava overrides a nivell de codi.

## Aproximació
- nova ruta `#/preferences`
- secció d'aparença amb `Clar`, `Fosc` i `Sistema`
- secció avançada de sync amb:
  - `PeerJS host`
  - `PeerJS port`
  - `PeerJS path`
  - `HTTP/HTTPS`
  - llista de servidors `STUN`
- persistència amb `localStorage`
- reutilització automàtica dels valors guardats quan s'obre una sessió de sync

## Scope
- `src/App.tsx`
- `src/features/groups/GroupList.tsx`
- `src/features/groups/Preferences.tsx`
- `src/hooks/useSync.ts`
- `src/lib/sync-preferences.ts`

## Notes
- el suport `TURN` queda fora d'aquesta PR i es deixa com a pas posterior
- aquestes preferències són locals del dispositiu, no del grup

## Validació
- `npm run lint`
- `npm test`
- `npm run build`
