### PR TITLE
feat: improve first-group activation empty state

### DIFF
--- a/src/features/expenses/ExpenseList.tsx
+++ b/src/features/expenses/ExpenseList.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react'
-import { Plus, Trash2, Camera, ImagePlus, X, Archive, ArchiveRestore, Pencil } from 'lucide-react'
+import { Plus, Trash2, Camera, ImagePlus, X, Archive, ArchiveRestore, Pencil, Sparkles, Users, ArrowRight } from 'lucide-react'
 import type { Group, Expense } from '../../domain/entities'
 import { computeExpenseShares, calculateBalances, isExpenseArchivable } from '../../domain/services/balances'
 import { useStore } from '../../store'
@@ -309,12 +309,17 @@ export function ExpenseList({ group }: ExpenseListProps) {
   return (
     <div>
       {activeMembers.length < 2 ? (
-        <Card className="border-dashed">
-          <CardContent className="py-6 text-center space-y-3">
-            <p className="font-medium">Falta com a mínim una altra persona</p>
-            <p className="text-sm text-muted-foreground max-w-md mx-auto">
-              Per començar a repartir despeses necessites almenys 2 membres al grup. Afegeix algú més i després ja podràs registrar la primera despesa.
-            </p>
+        <Card className="border-dashed bg-muted/20 shadow-none">
+          <CardContent className="py-7 px-5 text-center space-y-4">
+            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-background shadow-sm">
+              <Users className="h-5 w-5 text-muted-foreground" />
+            </div>
+            <div className="space-y-2">
+              <p className="text-lg font-semibold">Falta com a mínim una altra persona</p>
+              <p className="text-sm leading-6 text-muted-foreground max-w-md mx-auto">
+                Per començar a repartir despeses necessites almenys 2 membres al grup. Afegeix algú més i després ja podràs registrar la primera despesa.
+              </p>
+            </div>
           </CardContent>
         </Card>
       ) : (
@@ -647,30 +652,50 @@ export function ExpenseList({ group }: ExpenseListProps) {
             No hi ha despeses arxivades.
           </p>
         ) : (
-          <Card className="border-dashed bg-muted/20">
-            <CardContent className="py-6 space-y-4">
-              <div className="space-y-2 text-center">
-                <p className="font-medium">Aquest grup encara està buit</p>
-                <p className="text-sm text-muted-foreground max-w-md mx-auto">
-                  El primer valor arriba quan afegiu les primeres despeses reals. Comença amb alguna cosa simple, com un sopar, una compra compartida o un pagament del pis.
-                </p>
+          <Card className="overflow-hidden border-0 bg-gradient-to-b from-primary/5 via-background to-background shadow-sm">
+            <CardContent className="space-y-6 px-5 py-7 sm:px-6">
+              <div className="space-y-4 text-center">
+                <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-primary/10 text-primary">
+                  <Sparkles className="h-6 w-6" />
+                </div>
+                <div className="space-y-2">
+                  <p className="text-xl font-semibold">Aquest grup encara està buit</p>
+                  <p className="text-sm leading-6 text-muted-foreground max-w-md mx-auto">
+                    El primer valor arriba quan afegiu les primeres despeses reals. Comença amb alguna cosa simple i en un moment ja veureu qui deu què.
+                  </p>
+                </div>
               </div>
 
-              <div className="grid gap-2 sm:grid-cols-3">
-                <Button type="button" variant="outline" onClick={startCreate} disabled={group.archived}>
-                  Sopar
+              <div className="grid gap-3 sm:grid-cols-3">
+                <Button type="button" variant="outline" className="h-auto min-h-20 flex-col gap-1.5 rounded-xl border bg-background px-4 py-4 text-center shadow-sm hover:bg-accent" onClick={startCreate} disabled={group.archived}>
+                  <span className="text-lg">🍽️</span>
+                  <span className="font-semibold">Sopar</span>
+                  <span className="text-xs text-muted-foreground">Restaurant, esmorzar, tapes</span>
                 </Button>
-                <Button type="button" variant="outline" onClick={startCreate} disabled={group.archived}>
-                  Compra
+                <Button type="button" variant="outline" className="h-auto min-h-20 flex-col gap-1.5 rounded-xl border bg-background px-4 py-4 text-center shadow-sm hover:bg-accent" onClick={startCreate} disabled={group.archived}>
+                  <span className="text-lg">🛒</span>
+                  <span className="font-semibold">Compra</span>
+                  <span className="text-xs text-muted-foreground">Supermercat, supplies, casa</span>
                 </Button>
-                <Button type="button" variant="outline" onClick={startCreate} disabled={group.archived}>
-                  Transport
+                <Button type="button" variant="outline" className="h-auto min-h-20 flex-col gap-1.5 rounded-xl border bg-background px-4 py-4 text-center shadow-sm hover:bg-accent" onClick={startCreate} disabled={group.archived}>
+                  <span className="text-lg">🚌</span>
+                  <span className="font-semibold">Transport</span>
+                  <span className="text-xs text-muted-foreground">Taxi, benzina, bitllets</span>
                 </Button>
               </div>
 
-              <div className="rounded-lg border bg-background p-3 text-sm text-muted-foreground space-y-1">
-                <p className="font-medium text-foreground">Què passarà després?</p>
-                <p>Quan hi hagi moviment, Reparteix et calcularà automàticament qui deu què i com liquidar-ho amb menys fricció.</p>
+              <div className="rounded-2xl border bg-background/80 p-4 shadow-sm">
+                <div className="flex items-start gap-3">
+                  <div className="mt-0.5 rounded-full bg-primary/10 p-2 text-primary">
+                    <ArrowRight className="h-4 w-4" />
+                  </div>
+                  <div className="space-y-1.5">
+                    <p className="font-medium text-foreground">Què passarà després?</p>
+                    <p className="text-sm leading-6 text-muted-foreground">
+                      Quan hi hagi moviment, Reparteix et calcularà automàticament qui deu què i com liquidar-ho amb menys fricció.
+                    </p>
+                  </div>
+                </div>
               </div>
             </CardContent>
           </Card>

--- a/src/features/expenses/ExpenseList.tsx
+++ b/src/features/expenses/ExpenseList.tsx
@@ -33,6 +33,24 @@ const CURRENCY_SYMBOLS: Record<string, string> = {
   GBP: '£',
 }
 
+const emptyStateCtas = [
+  {
+    emoji: '🍽️',
+    title: 'Sopar',
+    subtitle: 'Restaurant, esmorzar, tapes',
+  },
+  {
+    emoji: '🛒',
+    title: 'Compra',
+    subtitle: 'Supermercat, subministraments, casa',
+  },
+  {
+    emoji: '🚌',
+    title: 'Transport',
+    subtitle: 'Taxi, benzina, bitllets',
+  },
+] as const
+
 interface ExpenseListProps {
   group: Group
 }
@@ -315,9 +333,9 @@ export function ExpenseList({ group }: ExpenseListProps) {
               <Users className="h-5 w-5 text-muted-foreground" />
             </div>
             <div className="space-y-2">
-              <p className="text-lg font-semibold">Falta com a mínim una altra persona</p>
+              <p className="text-lg font-semibold">Calen almenys 2 membres</p>
               <p className="text-sm leading-6 text-muted-foreground max-w-md mx-auto">
-                Per començar a repartir despeses necessites almenys 2 membres al grup. Afegeix algú més i després ja podràs registrar la primera despesa.
+                Per començar a repartir despeses necessites almenys 2 membres al grup. Afegeix-los i després ja podràs registrar la primera despesa.
               </p>
             </div>
           </CardContent>
@@ -667,21 +685,20 @@ export function ExpenseList({ group }: ExpenseListProps) {
               </div>
 
               <div className="grid gap-3 sm:grid-cols-3">
-                <Button type="button" variant="outline" className="h-auto min-h-20 flex-col gap-1.5 rounded-xl border bg-background px-4 py-4 text-center shadow-sm hover:bg-accent" onClick={startCreate} disabled={group.archived}>
-                  <span className="text-lg">🍽️</span>
-                  <span className="font-semibold">Sopar</span>
-                  <span className="text-xs text-muted-foreground">Restaurant, esmorzar, tapes</span>
-                </Button>
-                <Button type="button" variant="outline" className="h-auto min-h-20 flex-col gap-1.5 rounded-xl border bg-background px-4 py-4 text-center shadow-sm hover:bg-accent" onClick={startCreate} disabled={group.archived}>
-                  <span className="text-lg">🛒</span>
-                  <span className="font-semibold">Compra</span>
-                  <span className="text-xs text-muted-foreground">Supermercat, supplies, casa</span>
-                </Button>
-                <Button type="button" variant="outline" className="h-auto min-h-20 flex-col gap-1.5 rounded-xl border bg-background px-4 py-4 text-center shadow-sm hover:bg-accent" onClick={startCreate} disabled={group.archived}>
-                  <span className="text-lg">🚌</span>
-                  <span className="font-semibold">Transport</span>
-                  <span className="text-xs text-muted-foreground">Taxi, benzina, bitllets</span>
-                </Button>
+                {emptyStateCtas.map((cta) => (
+                  <Button
+                    key={cta.title}
+                    type="button"
+                    variant="outline"
+                    className="h-auto min-h-20 flex-col gap-1.5 rounded-xl border bg-background px-4 py-4 text-center shadow-sm hover:bg-accent"
+                    onClick={startCreate}
+                    disabled={group.archived}
+                  >
+                    <span className="text-lg">{cta.emoji}</span>
+                    <span className="font-semibold">{cta.title}</span>
+                    <span className="text-xs text-muted-foreground">{cta.subtitle}</span>
+                  </Button>
+                ))}
               </div>
 
               <div className="rounded-2xl border bg-background/80 p-4 shadow-sm">

--- a/src/features/expenses/ExpenseList.tsx
+++ b/src/features/expenses/ExpenseList.tsx
@@ -309,7 +309,7 @@ export function ExpenseList({ group }: ExpenseListProps) {
   return (
     <div>
       {activeMembers.length < 2 ? (
-        <Card className="border-dashed bg-muted/20 shadow-none">
+        <Card className="mb-5 border-dashed bg-muted/20 shadow-none">
           <CardContent className="py-7 px-5 text-center space-y-4">
             <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-background shadow-sm">
               <Users className="h-5 w-5 text-muted-foreground" />
@@ -652,7 +652,7 @@ export function ExpenseList({ group }: ExpenseListProps) {
             No hi ha despeses arxivades.
           </p>
         ) : (
-          <Card className="overflow-hidden border-0 bg-gradient-to-b from-primary/5 via-background to-background shadow-sm">
+          <Card className="mt-5 overflow-hidden border-0 bg-gradient-to-b from-primary/5 via-background to-background shadow-sm">
             <CardContent className="space-y-6 px-5 py-7 sm:px-6">
               <div className="space-y-4 text-center">
                 <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-primary/10 text-primary">

--- a/src/features/expenses/ExpenseList.tsx
+++ b/src/features/expenses/ExpenseList.tsx
@@ -309,9 +309,14 @@ export function ExpenseList({ group }: ExpenseListProps) {
   return (
     <div>
       {activeMembers.length < 2 ? (
-        <p className="text-muted-foreground text-center py-4">
-          Afegeix almenys 2 membres per poder crear despeses.
-        </p>
+        <Card className="border-dashed">
+          <CardContent className="py-6 text-center space-y-3">
+            <p className="font-medium">Falta com a mínim una altra persona</p>
+            <p className="text-sm text-muted-foreground max-w-md mx-auto">
+              Per començar a repartir despeses necessites almenys 2 membres al grup. Afegeix algú més i després ja podràs registrar la primera despesa.
+            </p>
+          </CardContent>
+        </Card>
       ) : (
         <>
           {!showForm ? (
@@ -637,9 +642,39 @@ export function ExpenseList({ group }: ExpenseListProps) {
       )}
 
       {visibleExpenses.length === 0 ? (
-        <p className="text-muted-foreground text-center py-4">
-          {showArchived ? 'No hi ha despeses arxivades.' : 'Encara no hi ha despeses.'}
-        </p>
+        showArchived ? (
+          <p className="text-muted-foreground text-center py-4">
+            No hi ha despeses arxivades.
+          </p>
+        ) : (
+          <Card className="border-dashed bg-muted/20">
+            <CardContent className="py-6 space-y-4">
+              <div className="space-y-2 text-center">
+                <p className="font-medium">Aquest grup encara està buit</p>
+                <p className="text-sm text-muted-foreground max-w-md mx-auto">
+                  El primer valor arriba quan afegiu les primeres despeses reals. Comença amb alguna cosa simple, com un sopar, una compra compartida o un pagament del pis.
+                </p>
+              </div>
+
+              <div className="grid gap-2 sm:grid-cols-3">
+                <Button type="button" variant="outline" onClick={startCreate} disabled={group.archived}>
+                  Sopar
+                </Button>
+                <Button type="button" variant="outline" onClick={startCreate} disabled={group.archived}>
+                  Compra
+                </Button>
+                <Button type="button" variant="outline" onClick={startCreate} disabled={group.archived}>
+                  Transport
+                </Button>
+              </div>
+
+              <div className="rounded-lg border bg-background p-3 text-sm text-muted-foreground space-y-1">
+                <p className="font-medium text-foreground">Què passarà després?</p>
+                <p>Quan hi hagi moviment, Reparteix et calcularà automàticament qui deu què i com liquidar-ho amb menys fricció.</p>
+              </div>
+            </CardContent>
+          </Card>
+        )
       ) : (
         <div className="space-y-4">
           {expensesByDay.map(({ date, items }) => (


### PR DESCRIPTION
Closes #118

## Summary
- improve the empty state when a group has members but no expenses yet
- explain the next step more clearly
- add quick CTA buttons to start creating the first expense
- make the value of balances/settlement visible earlier

## Validation
- corepack pnpm lint