### PR TITLE
feat: make receipts more visible and contextual

### DIFF
--- a/src/features/expenses/ExpenseList.tsx
+++ b/src/features/expenses/ExpenseList.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react'
-import { Plus, Trash2, Camera, ImagePlus, X, Archive, ArchiveRestore, Pencil, Sparkles, Users, ArrowRight } from 'lucide-react'
+import { Plus, Trash2, Camera, ImagePlus, X, Archive, ArchiveRestore, Pencil, Sparkles, Users, ArrowRight, Paperclip } from 'lucide-react'
 import type { Group, Expense } from '../../domain/entities'
 import { computeExpenseShares, calculateBalances, isExpenseArchivable } from '../../domain/services/balances'
 import { useStore } from '../../store'
@@ -847,24 +847,22 @@ export function ExpenseList({ group }: ExpenseListProps) {
                           </div>
                           <div className="flex items-center gap-1">
                             {expense.receiptImage && (
-                              <button
-                                type="button"
+                              <Button
+                                variant="ghost"
+                                size="sm"
                                 onClick={() => setViewingReceipt({
                                   image: expense.receiptImage ?? '',
                                   description: expense.description,
                                   amount: expense.amount,
                                   payerName: getMemberName(expense.payerId),
                                 })}
-                                aria-label="Veure rebut"
-                                className="overflow-hidden rounded-md border bg-background hover:opacity-90 transition-opacity"
-                                title="Veure rebut"
+                                aria-label="Veure rebut adjunt"
+                                className="h-auto px-1 py-0 text-xs text-muted-foreground hover:text-foreground"
+                                title="Veure rebut adjunt"
                               >
-                                <img
-                                  src={expense.receiptImage}
-                                  alt={`Rebut de ${expense.description}`}
-                                  className="h-8 w-8 object-cover"
-                                />
-                              </button>
+                                <Paperclip className="mr-1 h-3.5 w-3.5" />
+                                Adjunt
+                              </Button>
                             )}
                             {!showArchived && !group.archived && (
                               <Button

--- a/src/features/expenses/ExpenseList.tsx
+++ b/src/features/expenses/ExpenseList.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react'
-import { Plus, Trash2, Camera, ImagePlus, X, Archive, ArchiveRestore, Pencil, Sparkles, Users, ArrowRight, ReceiptText, Expand } from 'lucide-react'
+import { Plus, Trash2, Camera, ImagePlus, X, Archive, ArchiveRestore, Pencil, Sparkles, Users, ArrowRight } from 'lucide-react'
 import type { Group, Expense } from '../../domain/entities'
 import { computeExpenseShares, calculateBalances, isExpenseArchivable } from '../../domain/services/balances'
 import { useStore } from '../../store'
@@ -822,15 +822,7 @@ export function ExpenseList({ group }: ExpenseListProps) {
                     <Card key={expense.id} className={cn(showArchived && 'opacity-75')}>
                       <CardContent className="flex items-center justify-between p-3">
                         <div className="flex-1 space-y-1">
-                          <div className="flex items-center gap-2 flex-wrap">
-                            <div className="font-medium">{expense.description}</div>
-                            {expense.receiptImage && (
-                              <span className="inline-flex items-center gap-1 rounded-full border bg-muted/40 px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
-                                <ReceiptText className="h-3 w-3" />
-                                Amb rebut
-                              </span>
-                            )}
-                          </div>
+                          <div className="font-medium">{expense.description}</div>
                           <div className="text-sm text-muted-foreground flex items-center gap-1.5">
                             <span
                               className="inline-block h-2 w-2 rounded-full shrink-0"
@@ -848,9 +840,8 @@ export function ExpenseList({ group }: ExpenseListProps) {
                           </div>
                           <div className="flex items-center gap-1">
                             {expense.receiptImage && (
-                              <Button
-                                variant="ghost"
-                                size="sm"
+                              <button
+                                type="button"
                                 onClick={() => setViewingReceipt({
                                   image: expense.receiptImage ?? '',
                                   description: expense.description,
@@ -858,11 +849,15 @@ export function ExpenseList({ group }: ExpenseListProps) {
                                   payerName: getMemberName(expense.payerId),
                                 })}
                                 aria-label="Veure rebut"
-                                className="h-auto px-1.5 py-0 text-xs text-muted-foreground hover:text-foreground"
+                                className="overflow-hidden rounded-md border bg-background hover:opacity-90 transition-opacity"
+                                title="Veure rebut"
                               >
-                                <Expand className="mr-1 h-3 w-3" />
-                                Rebut
-                              </Button>
+                                <img
+                                  src={expense.receiptImage}
+                                  alt={`Rebut de ${expense.description}`}
+                                  className="h-8 w-8 object-cover"
+                                />
+                              </button>
                             )}
                             {!showArchived && !group.archived && (
                               <Button

--- a/src/features/expenses/ExpenseList.tsx
+++ b/src/features/expenses/ExpenseList.tsx
@@ -122,6 +122,13 @@ interface ExpenseListProps {
   group: Group
 }
 
+interface ViewingReceiptState {
+  image: string
+  description: string
+  amount: number
+  payerName: string
+}
+
 export function ExpenseList({ group }: ExpenseListProps) {
   const { expenses, payments, addExpense, updateExpense, deleteExpense, archiveAllSettledExpenses, unarchiveExpense } = useStore()
   const [editingExpenseId, setEditingExpenseId] = useState<string | null>(null)
@@ -134,7 +141,7 @@ export function ExpenseList({ group }: ExpenseListProps) {
   const [fixedAmounts, setFixedAmounts] = useState<Record<string, string>>({})
   const [showForm, setShowForm] = useState(false)
   const [receiptImage, setReceiptImage] = useState<string | null>(null)
-  const [viewingReceipt, setViewingReceipt] = useState<{ image: string; description: string; amount: number; payerName: string } | null>(null)
+  const [viewingReceipt, setViewingReceipt] = useState<ViewingReceiptState | null>(null)
   const [receiptError, setReceiptError] = useState<string | null>(null)
   const [showArchived, setShowArchived] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -666,7 +673,7 @@ export function ExpenseList({ group }: ExpenseListProps) {
                     </div>
                   )}
                   <div className="space-y-1">
-                    <Label>Foto del tiquet</Label>
+                    <Label>Foto del rebut</Label>
                     <input
                       ref={fileInputRef}
                       type="file"
@@ -686,7 +693,7 @@ export function ExpenseList({ group }: ExpenseListProps) {
                       <div className="relative w-fit space-y-2">
                         <img
                           src={receiptImage}
-                          alt="Tiquet"
+                          alt="Rebut"
                           className="max-h-[200px] rounded-md border object-contain"
                         />
                         <div className="rounded-md border bg-muted/30 px-2 py-1 text-xs text-muted-foreground">
@@ -941,7 +948,7 @@ export function ExpenseList({ group }: ExpenseListProps) {
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/70"
           role="dialog"
           aria-modal="true"
-          aria-label="Visor del tiquet"
+          aria-label="Visor del rebut"
           tabIndex={-1}
           onClick={() => setViewingReceipt(null)}
           onKeyDown={(e) => {
@@ -956,7 +963,7 @@ export function ExpenseList({ group }: ExpenseListProps) {
           >
             <img
               src={viewingReceipt.image}
-              alt="Tiquet"
+              alt="Rebut"
               className="max-w-full max-h-[85vh] rounded-lg object-contain shadow-lg"
             />
             <div className="absolute left-2 top-2 max-w-[70vw] rounded-lg bg-card/95 px-3 py-2 shadow">

--- a/src/features/expenses/ExpenseList.tsx
+++ b/src/features/expenses/ExpenseList.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react'
-import { Plus, Trash2, Camera, ImagePlus, X, Archive, ArchiveRestore, Pencil, Sparkles, Users, ArrowRight } from 'lucide-react'
+import { Plus, Trash2, Camera, ImagePlus, X, Archive, ArchiveRestore, Pencil, Sparkles, Users, ArrowRight, ReceiptText, Expand } from 'lucide-react'
 import type { Group, Expense } from '../../domain/entities'
 import { computeExpenseShares, calculateBalances, isExpenseArchivable } from '../../domain/services/balances'
 import { useStore } from '../../store'
@@ -134,7 +134,7 @@ export function ExpenseList({ group }: ExpenseListProps) {
   const [fixedAmounts, setFixedAmounts] = useState<Record<string, string>>({})
   const [showForm, setShowForm] = useState(false)
   const [receiptImage, setReceiptImage] = useState<string | null>(null)
-  const [viewingReceipt, setViewingReceipt] = useState<string | null>(null)
+  const [viewingReceipt, setViewingReceipt] = useState<{ image: string; description: string; amount: number; payerName: string } | null>(null)
   const [receiptError, setReceiptError] = useState<string | null>(null)
   const [showArchived, setShowArchived] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -683,12 +683,15 @@ export function ExpenseList({ group }: ExpenseListProps) {
                       onChange={handleFileChange}
                     />
                     {receiptImage ? (
-                      <div className="relative w-fit">
+                      <div className="relative w-fit space-y-2">
                         <img
                           src={receiptImage}
                           alt="Tiquet"
                           className="max-h-[200px] rounded-md border object-contain"
                         />
+                        <div className="rounded-md border bg-muted/30 px-2 py-1 text-xs text-muted-foreground">
+                          El rebut quedarà adjunt a aquesta despesa com a context visual.
+                        </div>
                         <button
                           type="button"
                           onClick={() => {
@@ -817,8 +820,16 @@ export function ExpenseList({ group }: ExpenseListProps) {
                   return (
                     <Card key={expense.id} className={cn(showArchived && 'opacity-75')}>
                       <CardContent className="flex items-center justify-between p-3">
-                        <div className="flex-1">
-                          <div className="font-medium">{expense.description}</div>
+                        <div className="flex-1 space-y-1">
+                          <div className="flex items-center gap-2 flex-wrap">
+                            <div className="font-medium">{expense.description}</div>
+                            {expense.receiptImage && (
+                              <span className="inline-flex items-center gap-1 rounded-full border bg-muted/40 px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
+                                <ReceiptText className="h-3 w-3" />
+                                Amb rebut
+                              </span>
+                            )}
+                          </div>
                           <div className="text-sm text-muted-foreground flex items-center gap-1.5">
                             <span
                               className="inline-block h-2 w-2 rounded-full shrink-0"
@@ -839,11 +850,17 @@ export function ExpenseList({ group }: ExpenseListProps) {
                               <Button
                                 variant="ghost"
                                 size="sm"
-                                onClick={() => setViewingReceipt(expense.receiptImage ?? null)}
-                                aria-label="Veure tiquet"
-                                className="h-auto px-1 py-0 text-xs text-muted-foreground hover:text-foreground"
+                                onClick={() => setViewingReceipt({
+                                  image: expense.receiptImage ?? '',
+                                  description: expense.description,
+                                  amount: expense.amount,
+                                  payerName: getMemberName(expense.payerId),
+                                })}
+                                aria-label="Veure rebut"
+                                className="h-auto px-1.5 py-0 text-xs text-muted-foreground hover:text-foreground"
                               >
-                                <Camera className="h-3 w-3" />
+                                <Expand className="mr-1 h-3 w-3" />
+                                Rebut
                               </Button>
                             )}
                             {!showArchived && !group.archived && (
@@ -942,10 +959,16 @@ export function ExpenseList({ group }: ExpenseListProps) {
             onClick={(e) => e.stopPropagation()}
           >
             <img
-              src={viewingReceipt}
+              src={viewingReceipt.image}
               alt="Tiquet"
               className="max-w-full max-h-[85vh] rounded-lg object-contain shadow-lg"
             />
+            <div className="absolute left-2 top-2 max-w-[70vw] rounded-lg bg-card/95 px-3 py-2 shadow">
+              <p className="text-sm font-medium">{viewingReceipt.description}</p>
+              <p className="text-xs text-muted-foreground">
+                {viewingReceipt.payerName} ha pagat · {viewingReceipt.amount.toFixed(2)} {symbol}
+              </p>
+            </div>
             <button
               type="button"
               onClick={() => setViewingReceipt(null)}

--- a/src/features/expenses/ExpenseList.tsx
+++ b/src/features/expenses/ExpenseList.tsx
@@ -695,6 +695,7 @@ export function ExpenseList({ group }: ExpenseListProps) {
                         <button
                           type="button"
                           onClick={() => {
+                            receiptLoadRequestRef.current += 1
                             setReceiptImage(null)
                             setReceiptError(null)
                           }}


### PR DESCRIPTION
Closes #122

## Summary
- make receipts more visible in the expense list with a clearer badge/state
- turn the receipt action into a labeled action instead of a tiny icon
- add more context inside the receipt viewer so the image stays tied to the expense
- reinforce during expense creation that the receipt becomes visual context for the expense

## Validation
- corepack pnpm lint