### PR TITLE
feat: make import and export feel like continuity

### DIFF
--- a/src/features/groups/GroupList.tsx
+++ b/src/features/groups/GroupList.tsx
@@ -171,7 +171,7 @@ export function GroupList() {
             <div>
               <h1 className="text-4xl font-bold tracking-tight mb-2">🧾 Reparteix</h1>
               <p className="text-indigo-200 text-base">
-                Gestiona despeses compartides de forma senzilla, local i privada.
+                Despeses compartides sense complicacions, sense comptes i amb les dades sota control.
               </p>
             </div>
             <Button
@@ -242,7 +242,7 @@ export function GroupList() {
                         onClick={() => navigate('/onboarding')}
                         className="gap-1.5"
                       >
-                        Crear en 1 minut
+                        Començar en 1 minut
                       </Button>
                     )}
                     <Button
@@ -313,7 +313,7 @@ export function GroupList() {
               </div>
               <h2 className="text-xl font-bold mb-2">Crea el teu primer grup</h2>
               <p className="text-muted-foreground text-sm mb-8 max-w-xs">
-                Afegeix persones i comença a registrar despeses compartides de manera senzilla.
+                Afegeix la gent, apunta la primera despesa i comença a veure el balanç sense embolics.
               </p>
 
               {showForm ? (
@@ -355,7 +355,7 @@ export function GroupList() {
                     className="w-full text-muted-foreground gap-2"
                   >
                     <Upload className="h-4 w-4" />
-                    Importar des de fitxer
+                    Recuperar des d’un fitxer
                   </Button>
                 </div>
               )}

--- a/src/features/groups/GroupSettings.tsx
+++ b/src/features/groups/GroupSettings.tsx
@@ -218,10 +218,10 @@ function GroupSettingsForm({ group, groupId }: GroupSettingsFormProps) {
             </p>
           </div>
 
-          <div className="space-y-3">
-            <div className="rounded-xl border p-4 space-y-3">
+          <ol className="space-y-3">
+            <li className="rounded-xl border p-4 space-y-3">
               <div>
-                <p className="font-medium">1. Sincronitzar ara entre dos dispositius</p>
+                <h3 className="font-medium">1. Sincronitzar ara entre dos dispositius</h3>
                 <p className="text-sm text-muted-foreground">
                   Ideal si vols continuar el mateix grup immediatament al teu mòbil, tauleta o un altre navegador.
                 </p>
@@ -229,11 +229,11 @@ function GroupSettingsForm({ group, groupId }: GroupSettingsFormProps) {
               <Suspense fallback={<p className="text-sm text-muted-foreground">Carregant sincronització…</p>}>
                 <SyncPanel groupId={groupId} />
               </Suspense>
-            </div>
+            </li>
 
-            <div className="rounded-xl border p-4 space-y-3">
+            <li className="rounded-xl border p-4 space-y-3">
               <div>
-                <p className="font-medium">2. Compartir el grup amb una altra persona</p>
+                <h3 className="font-medium">2. Compartir el grup amb una altra persona</h3>
                 <p className="text-sm text-muted-foreground">
                   Genera un enllaç perquè una altra persona el pugui obrir, revisar i importar al seu dispositiu.
                 </p>
@@ -256,11 +256,11 @@ function GroupSettingsForm({ group, groupId }: GroupSettingsFormProps) {
               {shareStatus === 'error' && (
                 <p className="text-sm text-destructive">Error en generar l'enllaç. Torna-ho a intentar.</p>
               )}
-            </div>
+            </li>
 
-            <div className="rounded-xl border p-4 space-y-3">
+            <li className="rounded-xl border p-4 space-y-3">
               <div>
-                <p className="font-medium">3. Guardar una còpia de seguretat</p>
+                <h3 className="font-medium">3. Guardar una còpia de seguretat</h3>
                 <p className="text-sm text-muted-foreground">
                   Exporta el grup a un fitxer per tenir-ne una còpia, moure'l manualment o recuperar-lo més endavant.
                 </p>
@@ -280,8 +280,8 @@ function GroupSettingsForm({ group, groupId }: GroupSettingsFormProps) {
               {exportStatus === 'error' && (
                 <p className="text-sm text-destructive">Error en exportar. Torna-ho a intentar.</p>
               )}
-            </div>
-          </div>
+            </li>
+          </ol>
         </CardContent>
       </Card>
 

--- a/src/features/groups/GroupSettings.tsx
+++ b/src/features/groups/GroupSettings.tsx
@@ -208,66 +208,82 @@ function GroupSettingsForm({ group, groupId }: GroupSettingsFormProps) {
 
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">Còpia de seguretat</CardTitle>
+          <CardTitle className="text-base">Continuïtat entre dispositius</CardTitle>
         </CardHeader>
-        <CardContent className="space-y-2">
-          <p className="text-sm text-muted-foreground">
-            Exporta totes les dades del grup (membres, despeses i pagaments) a un fitxer JSON per fer-ne una còpia de seguretat o migrar-les.
-          </p>
-          <Button
-            variant="outline"
-            className="w-full"
-            type="button"
-            onClick={handleExport}
-          >
-            <Download className="h-4 w-4 mr-2" />
-            Exportar JSON
-          </Button>
-          {exportStatus === 'ok' && (
-            <p className="text-sm text-success">Fitxer exportat correctament.</p>
-          )}
-          {exportStatus === 'error' && (
-            <p className="text-sm text-destructive">Error en exportar. Torna-ho a intentar.</p>
-          )}
+        <CardContent className="space-y-5">
+          <div className="rounded-xl border bg-muted/20 p-4 space-y-2">
+            <p className="text-sm font-medium">Porta aquest grup on el necessitis</p>
+            <p className="text-sm text-muted-foreground">
+              Pots continuar el grup en un altre dispositiu, compartir-lo amb una altra persona o guardar-ne una còpia de seguretat. Tria el camí segons el que vulguis fer ara.
+            </p>
+          </div>
+
+          <div className="space-y-3">
+            <div className="rounded-xl border p-4 space-y-3">
+              <div>
+                <p className="font-medium">1. Sincronitzar ara entre dos dispositius</p>
+                <p className="text-sm text-muted-foreground">
+                  Ideal si vols continuar el mateix grup immediatament al teu mòbil, tauleta o un altre navegador.
+                </p>
+              </div>
+              <Suspense fallback={<p className="text-sm text-muted-foreground">Carregant sincronització…</p>}>
+                <SyncPanel groupId={groupId} />
+              </Suspense>
+            </div>
+
+            <div className="rounded-xl border p-4 space-y-3">
+              <div>
+                <p className="font-medium">2. Compartir el grup amb una altra persona</p>
+                <p className="text-sm text-muted-foreground">
+                  Genera un enllaç perquè una altra persona el pugui obrir, revisar i importar al seu dispositiu.
+                </p>
+              </div>
+              <Button
+                variant="outline"
+                className="w-full"
+                type="button"
+                onClick={handleShare}
+              >
+                <Share2 className="h-4 w-4 mr-2" />
+                Compartir grup per enllaç
+              </Button>
+              {shareStatus === 'shared' && (
+                <p className="text-sm text-success">Enllaç compartit correctament.</p>
+              )}
+              {shareStatus === 'copied' && (
+                <p className="text-sm text-success">Enllaç copiat al porta-retalls.</p>
+              )}
+              {shareStatus === 'error' && (
+                <p className="text-sm text-destructive">Error en generar l'enllaç. Torna-ho a intentar.</p>
+              )}
+            </div>
+
+            <div className="rounded-xl border p-4 space-y-3">
+              <div>
+                <p className="font-medium">3. Guardar una còpia de seguretat</p>
+                <p className="text-sm text-muted-foreground">
+                  Exporta el grup a un fitxer per tenir-ne una còpia, moure'l manualment o recuperar-lo més endavant.
+                </p>
+              </div>
+              <Button
+                variant="outline"
+                className="w-full"
+                type="button"
+                onClick={handleExport}
+              >
+                <Download className="h-4 w-4 mr-2" />
+                Exportar còpia del grup
+              </Button>
+              {exportStatus === 'ok' && (
+                <p className="text-sm text-success">Fitxer exportat correctament.</p>
+              )}
+              {exportStatus === 'error' && (
+                <p className="text-sm text-destructive">Error en exportar. Torna-ho a intentar.</p>
+              )}
+            </div>
+          </div>
         </CardContent>
       </Card>
-
-      <Separator className="my-8" />
-
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">Compartir per enllaç</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-2">
-          <p className="text-sm text-muted-foreground">
-            Genera un enllaç per compartir el grup amb una altra persona. L'altra persona podrà previsualitzar i importar-lo al seu dispositiu.
-          </p>
-          <Button
-            variant="outline"
-            className="w-full"
-            type="button"
-            onClick={handleShare}
-          >
-            <Share2 className="h-4 w-4 mr-2" />
-            Compartir grup
-          </Button>
-          {shareStatus === 'shared' && (
-            <p className="text-sm text-success">Enllaç compartit correctament.</p>
-          )}
-          {shareStatus === 'copied' && (
-            <p className="text-sm text-success">Enllaç copiat al porta-retalls.</p>
-          )}
-          {shareStatus === 'error' && (
-            <p className="text-sm text-destructive">Error en generar l'enllaç. Torna-ho a intentar.</p>
-          )}
-        </CardContent>
-      </Card>
-
-      <Separator className="my-8" />
-
-      <Suspense fallback={<p className="text-sm text-muted-foreground">Carregant sincronització…</p>}>
-        <SyncPanel groupId={groupId} />
-      </Suspense>
 
       <Separator className="my-8" />
 

--- a/src/features/groups/OnboardingWizard.tsx
+++ b/src/features/groups/OnboardingWizard.tsx
@@ -206,14 +206,14 @@ export function OnboardingWizard() {
                 <Sparkles className="h-6 w-6" />
               </div>
               <div className="space-y-2">
-                <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">Crea un grup i veu el primer balanç en menys d’un minut</h1>
+                <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">Comença ràpid i veu el primer balanç en menys d’un minut</h1>
                 <p className="max-w-xl text-sm text-indigo-100 sm:text-base">
-                  Reparteix et guia pas a pas perquè entenguis el model ràpid: grup, membres, primera despesa i balanç.
+                  Crea un grup, afegeix la gent i apunta la primera despesa. La idea és que vegis valor de seguida, sense configuracions ni comptes.
                 </p>
               </div>
               <div className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-3 py-1 text-sm text-white/90 backdrop-blur">
                 <Shield className="h-4 w-4" />
-                Tot queda al teu dispositiu. No fem tracking ni enviem dades a tercers.
+                Sense comptes. Les dades queden sota el teu control des del primer moment.
               </div>
             </div>
             <div className="grid grid-cols-3 gap-2 text-center text-xs font-medium sm:w-72">
@@ -247,7 +247,7 @@ export function OnboardingWizard() {
               <div className="space-y-2">
                 <p className="text-sm font-medium text-indigo-600 dark:text-indigo-400">Pas 1</p>
                 <h2 className="text-2xl font-semibold tracking-tight">Com es diu el grup?</h2>
-                <p className="text-sm text-muted-foreground">Posa-li un nom clar. Després ja podràs afinar la resta des del grup.</p>
+                <p className="text-sm text-muted-foreground">Posa-li un nom clar i tira. La resta la podràs ajustar després, des del mateix grup.</p>
               </div>
               <div className="space-y-2">
                 <Label htmlFor="group-name">Nom del grup</Label>
@@ -279,7 +279,7 @@ export function OnboardingWizard() {
                   <p className="text-sm font-medium">Pas 2</p>
                 </div>
                 <h2 className="text-2xl font-semibold tracking-tight">Qui forma part del grup?</h2>
-                <p className="text-sm text-muted-foreground">Afegeix almenys dues persones perquè el balanç tingui sentit des del primer moment.</p>
+                <p className="text-sm text-muted-foreground">Afegeix qui participa al grup perquè el repartiment tingui sentit des del primer moment.</p>
               </div>
               <div className="space-y-3">
                 {draft.memberNames.map((memberName, index) => (
@@ -329,7 +329,7 @@ export function OnboardingWizard() {
               <div className="space-y-2">
                 <p className="text-sm font-medium text-indigo-600 dark:text-indigo-400">Pas 3</p>
                 <h2 className="text-2xl font-semibold tracking-tight">Registra la primera despesa</h2>
-                <p className="text-sm text-muted-foreground">Amb això ja veuràs el valor real del producte, qui ha pagat i com queda repartit.</p>
+                <p className="text-sm text-muted-foreground">Amb això ja veuràs qui ha pagat, com queda repartit i si algú ha d’abonar diners.</p>
               </div>
               <div className="space-y-2">
                 <Label htmlFor="expense-description">Quina ha estat la primera despesa?</Label>
@@ -411,7 +411,7 @@ export function OnboardingWizard() {
                 </div>
               </div>
               <div className="rounded-2xl border border-indigo-200 bg-indigo-50 p-4 text-sm text-indigo-900 dark:border-indigo-900 dark:bg-indigo-950/50 dark:text-indigo-100">
-                Aquest flux està pensat per ensenyar el model ràpid, no per fer-te configurar-ho tot d’entrada.
+                Aquest flux està pensat perquè comencis ràpid. Ja tindràs temps després per compartir, sincronitzar o guardar còpies del grup.
               </div>
             </div>
           </Card>


### PR DESCRIPTION
Closes #121

## Summary
- reframe sync, link sharing, and export under a single continuity narrative
- explain when each path should be used in plain product language
- reduce the technical feel of import/export by turning it into a continuity flow
- improve hierarchy in group settings so the available paths feel more natural

## Validation
- corepack pnpm lint