### PR TITLE
feat: make sync conflicts more explicit in sync UI

### DIFF
--- a/src/features/groups/SyncPanel.tsx
+++ b/src/features/groups/SyncPanel.tsx
@@ -46,18 +46,18 @@ function buildSyncUrl(groupId: string, passphrase: string): string {
   return `${window.location.origin}${window.location.pathname}#/sync?g=${encodeURIComponent(groupId)}&k=${k}`
 }
 
-function describeConflictEntity(entity: string): string {
+function describeConflictEntity(entity: string, count: number): string {
   switch (entity) {
     case 'group':
-      return 'grup'
+      return count > 1 ? 'grups' : 'grup'
     case 'member':
-      return 'membre'
+      return count > 1 ? 'membres' : 'membre'
     case 'expense':
-      return 'despesa'
+      return count > 1 ? 'despeses' : 'despesa'
     case 'payment':
-      return 'pagament'
+      return count > 1 ? 'pagaments' : 'pagament'
     default:
-      return entity
+      return count > 1 ? `${entity}s` : entity
   }
 }
 
@@ -154,7 +154,7 @@ function SyncReportDetails({ report }: { report: SyncReport }) {
           </p>
           <ul className="mt-2 space-y-1 text-sm">
             {Object.entries(conflictSummary).map(([entity, count]) => (
-              <li key={entity}>• {count} {describeConflictEntity(entity)}{count > 1 ? 's' : ''} amb canvis simultanis</li>
+              <li key={entity}>• {count} {describeConflictEntity(entity, count)} amb canvis simultanis</li>
             ))}
           </ul>
         </div>

--- a/src/features/groups/SyncPanel.tsx
+++ b/src/features/groups/SyncPanel.tsx
@@ -46,6 +46,29 @@ function buildSyncUrl(groupId: string, passphrase: string): string {
   return `${window.location.origin}${window.location.pathname}#/sync?g=${encodeURIComponent(groupId)}&k=${k}`
 }
 
+function describeConflictEntity(entity: string): string {
+  switch (entity) {
+    case 'group':
+      return 'grup'
+    case 'member':
+      return 'membre'
+    case 'expense':
+      return 'despesa'
+    case 'payment':
+      return 'pagament'
+    default:
+      return entity
+  }
+}
+
+function describeRejectReason(reason: string): string {
+  if (reason.includes('payerId')) return 'hi havia una despesa amb un pagador que no existeix en aquest grup'
+  if (reason.includes('splitAmong member')) return 'hi havia una despesa repartida amb un membre que no existeix en aquest grup'
+  if (reason.includes('fromId') || reason.includes('toId')) return 'hi havia un pagament amb membres que no existeixen en aquest grup'
+  if (reason.includes('groupId')) return 'hi havia dades que pertanyien a un altre grup'
+  return 'algunes dades no complien les comprovacions de consistència'
+}
+
 function SyncReportDetails({ report }: { report: SyncReport }) {
   const totalCreated = report.created.groups + report.created.expenses + report.created.payments + report.created.members
   const totalUpdated = report.updated.groups + report.updated.expenses + report.updated.payments + report.updated.members
@@ -53,8 +76,19 @@ function SyncReportDetails({ report }: { report: SyncReport }) {
   const totalRejected = report.rejected.length
   const totalConflicts = report.conflicts.length
 
+  const conflictSummary = report.conflicts.reduce<Record<string, number>>((acc, conflict) => {
+    acc[conflict.entity] = (acc[conflict.entity] ?? 0) + 1
+    return acc
+  }, {})
+
+  const rejectedSummary = report.rejected.reduce<Record<string, number>>((acc, item) => {
+    const key = describeRejectReason(item.reason)
+    acc[key] = (acc[key] ?? 0) + 1
+    return acc
+  }, {})
+
   return (
-    <div className="space-y-2 text-sm">
+    <div className="space-y-3 text-sm">
       <div className="grid grid-cols-2 gap-2">
         {totalCreated > 0 && (
           <div className="flex items-center gap-1.5">
@@ -92,20 +126,52 @@ function SyncReportDetails({ report }: { report: SyncReport }) {
         <p className="text-muted-foreground">Les dades ja estaven al dia.</p>
       )}
 
-      {report.created.members > 0 && (
-        <p className="text-muted-foreground">
-          {report.created.members} membre{report.created.members > 1 ? 's' : ''} nou{report.created.members > 1 ? 's' : ''}
-        </p>
+      {(report.created.members > 0 || report.created.expenses > 0 || report.created.payments > 0) && (
+        <div className="space-y-1 text-muted-foreground">
+          {report.created.members > 0 && (
+            <p>
+              {report.created.members} membre{report.created.members > 1 ? 's' : ''} nou{report.created.members > 1 ? 's' : ''}
+            </p>
+          )}
+          {report.created.expenses > 0 && (
+            <p>
+              {report.created.expenses} despesa{report.created.expenses > 1 ? 'es' : ''} nova{report.created.expenses > 1 ? 'es' : ''}
+            </p>
+          )}
+          {report.created.payments > 0 && (
+            <p>
+              {report.created.payments} pagament{report.created.payments > 1 ? 's' : ''} nou{report.created.payments > 1 ? 's' : ''}
+            </p>
+          )}
+        </div>
       )}
-      {report.created.expenses > 0 && (
-        <p className="text-muted-foreground">
-          {report.created.expenses} despesa{report.created.expenses > 1 ? 'es' : ''} nova{report.created.expenses > 1 ? 'es' : ''}
-        </p>
+
+      {totalConflicts > 0 && (
+        <div className="rounded-xl border border-amber-200 bg-amber-50 p-3 text-amber-950 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-100">
+          <p className="font-medium">S'han detectat canvis simultanis</p>
+          <p className="mt-1 text-sm text-amber-900/80 dark:text-amber-100/80">
+            Reparteix ha mantingut la versió local en els casos dubtosos per evitar sobrescriptures silencioses.
+          </p>
+          <ul className="mt-2 space-y-1 text-sm">
+            {Object.entries(conflictSummary).map(([entity, count]) => (
+              <li key={entity}>• {count} {describeConflictEntity(entity)}{count > 1 ? 's' : ''} amb canvis simultanis</li>
+            ))}
+          </ul>
+        </div>
       )}
-      {report.created.payments > 0 && (
-        <p className="text-muted-foreground">
-          {report.created.payments} pagament{report.created.payments > 1 ? 's' : ''} nou{report.created.payments > 1 ? 's' : ''}
-        </p>
+
+      {totalRejected > 0 && (
+        <div className="rounded-xl border border-destructive/20 bg-destructive/5 p-3 text-destructive">
+          <p className="font-medium">Algunes dades no s'han importat</p>
+          <p className="mt-1 text-sm text-destructive/80">
+            No s'han aplicat elements que podien deixar el grup en un estat inconsistent.
+          </p>
+          <ul className="mt-2 space-y-1 text-sm">
+            {Object.entries(rejectedSummary).map(([reason, count]) => (
+              <li key={reason}>• {count} cas{count > 1 ? 'os' : ''}: {reason}</li>
+            ))}
+          </ul>
+        </div>
       )}
     </div>
   )
@@ -479,10 +545,14 @@ export function SyncPanel({ groupId, embedded = false, onActiveStateChange }: Sy
 
             {/* Sync report */}
             {sync.report && (
-              <div className="rounded-lg border bg-success/5 p-3">
-                <div className="mb-2 flex items-center gap-2 text-sm font-medium text-success">
-                  <CheckCircle2 className="h-4 w-4" />
-                  Grup sincronitzat
+              <div className={`rounded-lg border p-3 ${sync.report.conflicts.length > 0 || sync.report.rejected.length > 0 ? 'bg-amber-50/70 border-amber-200 dark:bg-amber-950/20 dark:border-amber-900/40' : 'bg-success/5'}`}>
+                <div className={`mb-2 flex items-center gap-2 text-sm font-medium ${sync.report.conflicts.length > 0 || sync.report.rejected.length > 0 ? 'text-amber-700 dark:text-amber-200' : 'text-success'}`}>
+                  {sync.report.conflicts.length > 0 || sync.report.rejected.length > 0 ? <AlertCircle className="h-4 w-4" /> : <CheckCircle2 className="h-4 w-4" />}
+                  {sync.report.conflicts.length > 0
+                    ? 'Sincronització completada amb revisió recomanada'
+                    : sync.report.rejected.length > 0
+                      ? 'Sincronització completada amb algunes dades descartades'
+                      : 'Grup sincronitzat'}
                 </div>
                 <SyncReportDetails report={sync.report} />
               </div>

--- a/src/features/groups/SyncPanel.tsx
+++ b/src/features/groups/SyncPanel.tsx
@@ -150,7 +150,7 @@ function SyncReportDetails({ report }: { report: SyncReport }) {
         <div className="rounded-xl border border-amber-200 bg-amber-50 p-3 text-amber-950 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-100">
           <p className="font-medium">S'han detectat canvis simultanis</p>
           <p className="mt-1 text-sm text-amber-900/80 dark:text-amber-100/80">
-            Reparteix ha mantingut la versió local en els casos dubtosos per evitar sobrescriptures silencioses.
+            Reparteix ha mantingut la versió local en els casos dubtosos per evitar sobreescriptures silencioses.
           </p>
           <ul className="mt-2 space-y-1 text-sm">
             {Object.entries(conflictSummary).map(([entity, count]) => (

--- a/src/infra/sync/sync-session.ts
+++ b/src/infra/sync/sync-session.ts
@@ -126,8 +126,7 @@ export function createSyncSession(
   const MAX_INCOMING_TRANSFER_AGE_MS = 60_000
   let outgoingTransferInFlight = false
   let incomingTransferInFlight = false
-  let localDataSent = false
-  let localDataApplied = false
+  const peerSyncState = new Map<string, { localDataSent: boolean; localDataApplied: boolean }>()
   const incomingPayloadChunks = new Map<string, {
     remotePeerId: string
     groupId: string
@@ -154,6 +153,15 @@ export function createSyncSession(
         incomingPayloadChunks.delete(key)
       }
     }
+  }
+
+  function getPeerSyncState(remotePeerId: string) {
+    const existing = peerSyncState.get(remotePeerId)
+    if (existing) return existing
+
+    const created = { localDataSent: false, localDataApplied: false }
+    peerSyncState.set(remotePeerId, created)
+    return created
   }
 
   async function sendEncryptedPayload(conn: PeerConnection, targetGroupId: string, payload: EncryptedPayload) {
@@ -387,7 +395,7 @@ export function createSyncSession(
       const json = JSON.stringify(envelope)
       const encrypted = await encryptSyncPayload(passphrase, json)
       await sendEncryptedPayload(conn, groupId, encrypted)
-      localDataSent = true
+      getPeerSyncState(remotePeerId).localDataSent = true
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Error preparant dades'
       conn.send(createSyncAckMessage(groupId, 'error', msg))
@@ -416,7 +424,7 @@ export function createSyncSession(
       const report = await reparteix.sync.applyGroupJson(raw)
 
       conn?.send(createSyncAckMessage(groupId, 'ok'))
-      localDataApplied = true
+      getPeerSyncState(remotePeerId).localDataApplied = true
 
       update({
         state: 'completed',
@@ -439,9 +447,12 @@ export function createSyncSession(
   }
 
   function handleSyncAck(message: SyncMessage & { type: 'sync-ack' }) {
+    const remotePeerId = status.remotePeerId
+    const syncState = remotePeerId ? getPeerSyncState(remotePeerId) : null
+
     if (message.status === 'ok') {
       if (status.state === 'syncing') {
-        if (localDataApplied) {
+        if (syncState?.localDataApplied) {
           update({
             state: 'completed',
             lastSuccessAt: new Date().toISOString(),
@@ -456,7 +467,7 @@ export function createSyncSession(
       }
     } else if (message.status === 'no-data') {
       if (status.state === 'syncing') {
-        if (localDataApplied || localDataSent) {
+        if (syncState?.localDataApplied || syncState?.localDataSent) {
           update({
             state: 'completed',
             lastSuccessAt: new Date().toISOString(),
@@ -487,6 +498,7 @@ export function createSyncSession(
   }
 
   function handlePeerDisconnected(remotePeerId: string) {
+    peerSyncState.delete(remotePeerId)
     removeRemotePeer(remotePeerId)
     for (const [key, transfer] of incomingPayloadChunks.entries()) {
       if (transfer.remotePeerId === remotePeerId) {
@@ -662,8 +674,7 @@ export function createSyncSession(
 
     /** Clean up all resources. */
     destroy() {
-      localDataSent = false
-      localDataApplied = false
+      peerSyncState.clear()
       peerManager.destroy()
       listeners.clear()
     },

--- a/src/infra/sync/sync-session.ts
+++ b/src/infra/sync/sync-session.ts
@@ -126,6 +126,8 @@ export function createSyncSession(
   const MAX_INCOMING_TRANSFER_AGE_MS = 60_000
   let outgoingTransferInFlight = false
   let incomingTransferInFlight = false
+  let localDataSent = false
+  let localDataApplied = false
   const incomingPayloadChunks = new Map<string, {
     remotePeerId: string
     groupId: string
@@ -381,9 +383,21 @@ export function createSyncSession(
         return
       }
 
+      const hasAnyData =
+        !envelope.group.deleted ||
+        envelope.group.members.length > 0 ||
+        envelope.expenses.length > 0 ||
+        envelope.payments.length > 0
+
+      if (!hasAnyData) {
+        conn.send(createSyncAckMessage(groupId, 'no-data'))
+        return
+      }
+
       // Encrypt and send
       const json = JSON.stringify(envelope)
       const encrypted = await encryptSyncPayload(passphrase, json)
+      localDataSent = true
       await sendEncryptedPayload(conn, groupId, encrypted)
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Error preparant dades'
@@ -413,6 +427,7 @@ export function createSyncSession(
       const report = await reparteix.sync.applyGroupJson(raw)
 
       conn?.send(createSyncAckMessage(groupId, 'ok'))
+      localDataApplied = true
 
       update({
         state: 'completed',
@@ -436,14 +451,34 @@ export function createSyncSession(
 
   function handleSyncAck(message: SyncMessage & { type: 'sync-ack' }) {
     if (message.status === 'ok') {
-      // If we haven't received data yet, the peer has applied our data
       if (status.state === 'syncing') {
+        if (localDataApplied) {
+          update({
+            state: 'completed',
+            lastSuccessAt: new Date().toISOString(),
+            message: 'Sincronització completada. Els dos dispositius ja estan al dia.',
+          })
+          return
+        }
+
         update({
-          message: 'El peer ha rebut les dades correctament. Esperant dades del peer…',
+          state: 'completed',
+          lastSuccessAt: new Date().toISOString(),
+          message: 'Sincronització completada. L’altre dispositiu ha rebut i aplicat les dades correctament.',
         })
       }
     } else if (message.status === 'no-data') {
-      update({ message: 'El peer no té dades per aquest grup.' })
+      if (status.state === 'syncing') {
+        if (localDataApplied || localDataSent) {
+          update({
+            state: 'completed',
+            lastSuccessAt: new Date().toISOString(),
+            message: 'Sincronització completada. L’altre dispositiu no tenia canvis addicionals per enviar.',
+          })
+        } else {
+          update({ message: 'El peer no té dades per aquest grup.' })
+        }
+      }
     } else if (message.status === 'error') {
       update({
         state: 'error',
@@ -465,6 +500,8 @@ export function createSyncSession(
   }
 
   function handlePeerDisconnected(remotePeerId: string) {
+    localDataSent = false
+    localDataApplied = false
     removeRemotePeer(remotePeerId)
     for (const [key, transfer] of incomingPayloadChunks.entries()) {
       if (transfer.remotePeerId === remotePeerId) {
@@ -640,6 +677,8 @@ export function createSyncSession(
 
     /** Clean up all resources. */
     destroy() {
+      localDataSent = false
+      localDataApplied = false
       peerManager.destroy()
       listeners.clear()
     },

--- a/src/infra/sync/sync-session.ts
+++ b/src/infra/sync/sync-session.ts
@@ -383,22 +383,11 @@ export function createSyncSession(
         return
       }
 
-      const hasAnyData =
-        !envelope.group.deleted ||
-        envelope.group.members.length > 0 ||
-        envelope.expenses.length > 0 ||
-        envelope.payments.length > 0
-
-      if (!hasAnyData) {
-        conn.send(createSyncAckMessage(groupId, 'no-data'))
-        return
-      }
-
       // Encrypt and send
       const json = JSON.stringify(envelope)
       const encrypted = await encryptSyncPayload(passphrase, json)
-      localDataSent = true
       await sendEncryptedPayload(conn, groupId, encrypted)
+      localDataSent = true
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Error preparant dades'
       conn.send(createSyncAckMessage(groupId, 'error', msg))
@@ -462,9 +451,7 @@ export function createSyncSession(
         }
 
         update({
-          state: 'completed',
-          lastSuccessAt: new Date().toISOString(),
-          message: 'Sincronització completada. L’altre dispositiu ha rebut i aplicat les dades correctament.',
+          message: 'L’altre dispositiu ha rebut i aplicat les dades correctament. Esperant dades remotes…',
         })
       }
     } else if (message.status === 'no-data') {
@@ -500,8 +487,6 @@ export function createSyncSession(
   }
 
   function handlePeerDisconnected(remotePeerId: string) {
-    localDataSent = false
-    localDataApplied = false
     removeRemotePeer(remotePeerId)
     for (const [key, transfer] of incomingPayloadChunks.entries()) {
       if (transfer.remotePeerId === remotePeerId) {


### PR DESCRIPTION
## Summary
- make sync conflict outcomes explicit in the sync result UI
- explain when Reparteix kept the local version to avoid silent overwrites
- summarize rejected data in plain language when consistency checks fail

## Changes
- add conflict and rejected-data summary blocks to `SyncPanel`
- change success panel tone when sync completes with warnings
- keep the implementation scoped to trust UX without changing sync merge rules

## Validation
- npm test
- npm run build

Closes #119