### PR TITLE
copy: make import and export feel like continuity

### DIFF
--- a/src/features/groups/GroupList.tsx
+++ b/src/features/groups/GroupList.tsx
@@ -252,16 +252,16 @@ export function GroupList() {
                       className="text-muted-foreground gap-1.5"
                     >
                       <Upload className="h-3.5 w-3.5" />
-                      Importar
+                      Recuperar des d’un fitxer
                     </Button>
                   </div>
                 )}
                 {/* Import status messages */}
                 {importStatus === 'ok' && (
-                  <p className="text-sm text-success mt-2">Grup importat correctament. Redirigint…</p>
+                  <p className="text-sm text-success mt-2">Grup recuperat correctament. Redirigint…</p>
                 )}
                 {importStatus === 'error' && (
-                  <p className="text-sm text-destructive mt-2">Error en importar: {importError}</p>
+                  <p className="text-sm text-destructive mt-2">Error en recuperar el grup: {importError}</p>
                 )}
               </div>
             </Card>
@@ -313,7 +313,7 @@ export function GroupList() {
               </div>
               <h2 className="text-xl font-bold mb-2">Crea el teu primer grup</h2>
               <p className="text-muted-foreground text-sm mb-8 max-w-xs">
-                Afegeix la gent, apunta la primera despesa i comença a veure el balanç sense embolics.
+                Afegeix la gent, apunta la primera despesa i comença a veure el balanç sense embolics. Si ja el tens guardat, també el pots recuperar des d’un fitxer.
               </p>
 
               {showForm ? (
@@ -362,10 +362,10 @@ export function GroupList() {
 
               {/* Import status messages */}
               {importStatus === 'ok' && (
-                <p className="text-sm text-success mt-4">Grup importat correctament. Redirigint…</p>
+                <p className="text-sm text-success mt-4">Grup recuperat correctament. Redirigint…</p>
               )}
               {importStatus === 'error' && (
-                <p className="text-sm text-destructive mt-4">Error en importar: {importError}</p>
+                <p className="text-sm text-destructive mt-4">Error en recuperar el grup: {importError}</p>
               )}
             </div>
           </Card>

--- a/src/features/groups/GroupSettings.tsx
+++ b/src/features/groups/GroupSettings.tsx
@@ -208,11 +208,11 @@ function GroupSettingsForm({ group, groupId }: GroupSettingsFormProps) {
 
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">Còpia de seguretat</CardTitle>
+          <CardTitle className="text-base">Guardar una còpia del grup</CardTitle>
         </CardHeader>
         <CardContent className="space-y-2">
           <p className="text-sm text-muted-foreground">
-            Exporta totes les dades del grup (membres, despeses i pagaments) a un fitxer JSON per fer-ne una còpia de seguretat o migrar-les.
+            Desa aquest grup en un fitxer per recuperar-lo més endavant, portar-lo a un altre dispositiu o quedar-te una còpia de seguretat sota control teu.
           </p>
           <Button
             variant="outline"
@@ -221,7 +221,7 @@ function GroupSettingsForm({ group, groupId }: GroupSettingsFormProps) {
             onClick={handleExport}
           >
             <Download className="h-4 w-4 mr-2" />
-            Exportar JSON
+            Desar còpia en un fitxer
           </Button>
           {exportStatus === 'ok' && (
             <p className="text-sm text-success">Fitxer exportat correctament.</p>
@@ -240,7 +240,7 @@ function GroupSettingsForm({ group, groupId }: GroupSettingsFormProps) {
         </CardHeader>
         <CardContent className="space-y-2">
           <p className="text-sm text-muted-foreground">
-            Genera un enllaç per compartir el grup amb una altra persona. L'altra persona podrà previsualitzar i importar-lo al seu dispositiu.
+            Genera un enllaç perquè una altra persona, o tu mateix en un altre dispositiu, pugui obrir el grup i continuar des d'allà sense passar fitxers manualment.
           </p>
           <Button
             variant="outline"
@@ -249,7 +249,7 @@ function GroupSettingsForm({ group, groupId }: GroupSettingsFormProps) {
             onClick={handleShare}
           >
             <Share2 className="h-4 w-4 mr-2" />
-            Compartir grup
+            Continuar amb un enllaç
           </Button>
           {shareStatus === 'shared' && (
             <p className="text-sm text-success">Enllaç compartit correctament.</p>

--- a/src/features/groups/ImportFromUrl.tsx
+++ b/src/features/groups/ImportFromUrl.tsx
@@ -22,7 +22,7 @@ export function ImportFromUrl() {
   const navigate = useNavigate()
   const encoded = searchParams.get('g') ?? ''
   const [state, setState] = useState<ImportState>(() =>
-    encoded ? { status: 'loading' } : { status: 'error', message: 'No hi ha cap contingut per importar.' },
+    encoded ? { status: 'loading' } : { status: 'error', message: 'No hi ha cap contingut per recuperar.' },
   )
   const [report, setReport] = useState<SyncReport | null>(null)
 
@@ -123,8 +123,8 @@ export function ImportFromUrl() {
             <ArrowLeft className="h-5 w-5" />
           </Button>
           <div>
-            <h1 className="text-2xl font-bold">Importar grup</h1>
-            <p className="text-indigo-200 text-sm">Via enllaç de compartir</p>
+            <h1 className="text-2xl font-bold">Continuar un grup des d’un enllaç</h1>
+            <p className="text-indigo-200 text-sm">Obre un grup compartit i porta’l a aquest dispositiu</p>
           </div>
         </div>
       </div>
@@ -143,7 +143,7 @@ export function ImportFromUrl() {
             <CardContent className="py-10 flex flex-col items-center gap-4 text-center">
               <AlertCircle className="h-10 w-10 text-destructive" />
               <div>
-                <p className="font-semibold text-destructive">No s'ha pogut importar</p>
+                <p className="font-semibold text-destructive">No s'ha pogut recuperar el grup</p>
                 <p className="text-sm text-muted-foreground mt-1">{state.message}</p>
               </div>
               <Button variant="outline" onClick={() => navigate('/')}>
@@ -166,7 +166,7 @@ export function ImportFromUrl() {
         {state.status === 'importing' && (
           <Card className="shadow-md">
             <CardContent className="py-12 flex justify-center">
-              <p className="text-muted-foreground">Important…</p>
+              <p className="text-muted-foreground">Portant el grup a aquest dispositiu…</p>
             </CardContent>
           </Card>
         )}
@@ -176,7 +176,7 @@ export function ImportFromUrl() {
             <CardContent className="py-10 flex flex-col items-center gap-4 text-center">
               <CheckCircle className="h-10 w-10 text-success" />
               <div>
-                <p className="font-semibold text-success">Grup importat correctament</p>
+                <p className="font-semibold text-success">Grup recuperat correctament</p>
                 {report && <SyncReportSummary report={report} />}
               </div>
               <Button
@@ -211,7 +211,7 @@ function PreviewCard({ envelope, exists, onImport, onImportAsCopy, onCancel }: P
     <Card className="shadow-md">
       <CardHeader>
         <CardTitle className="text-base">
-          {exists ? 'Actualitzar grup existent' : 'Importar grup nou'}
+          {exists ? 'Continuar grup existent' : 'Portar grup nou a aquest dispositiu'}
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-6">
@@ -240,12 +240,12 @@ function PreviewCard({ envelope, exists, onImport, onImportAsCopy, onCancel }: P
         {exists ? (
           <p className="text-sm text-muted-foreground">
             Aquest grup ja existeix al teu dispositiu. Pots{' '}
-            <strong>actualitzar-lo</strong> (les dades més noves guanyen) o{' '}
-            <strong>importar-lo com a còpia nova</strong>.
+            <strong>posar-lo al dia</strong> amb les dades de l'enllaç o{' '}
+            <strong>portar-lo com una còpia nova</strong> si vols separar-lo de l'original.
           </p>
         ) : (
           <p className="text-sm text-muted-foreground">
-            Aquest grup no existeix al teu dispositiu. Es crearà nou amb totes les dades de l'enllaç.
+            Aquest grup encara no existeix en aquest dispositiu. El podràs portar aquí amb totes les dades de l'enllaç.
           </p>
         )}
 
@@ -255,11 +255,11 @@ function PreviewCard({ envelope, exists, onImport, onImportAsCopy, onCancel }: P
             className="w-full bg-indigo-600 hover:bg-indigo-700 dark:bg-indigo-500 dark:hover:bg-indigo-600 text-white"
             onClick={onImport}
           >
-            {exists ? 'Actualitzar / Fusionar' : 'Importar grup'}
+            {exists ? 'Posar al dia aquest grup' : 'Portar grup a aquest dispositiu'}
           </Button>
           {exists && (
             <Button variant="outline" className="w-full" onClick={onImportAsCopy}>
-              Importar com a còpia nova
+              Portar com a còpia nova
             </Button>
           )}
           <Button variant="ghost" className="w-full text-muted-foreground" onClick={onCancel}>


### PR DESCRIPTION
## Summary
- reframe import/export language around continuity, recovery, and moving between devices
- reduce technical wording in the current import/export entry points
- make shared-link import feel more like continuing a group on this device

## Changes
- update `GroupSettings` copy for export and share-by-link
- update `GroupList` import entry points and success/error messages
- update `ImportFromUrl` titles, CTA labels, and explanatory copy

## Validation
- corepack pnpm lint

Closes #121