### PR TITLE
feat: clarify sync handoff iconography

### DIFF
--- a/src/features/groups/GroupDetail.tsx
+++ b/src/features/groups/GroupDetail.tsx
@@ -145,25 +145,21 @@ export function GroupDetail() {
         {!isArchived && (
           <Button
             variant="ghost"
-            size="sm"
+            size="icon"
             onClick={() => setShowSyncModal(true)}
-            aria-label="Compartir"
-            title="Compartir"
-            className="gap-2"
+            aria-label="Obrir o compartir en un altre dispositiu"
+            title="Obrir o compartir en un altre dispositiu"
           >
-            <Share2 className="h-4 w-4" />
-            <span>Compartir</span>
+            <Share2 className="h-5 w-5" />
           </Button>
         )}
         <Button
           variant="ghost"
-          size="sm"
+          size="icon"
           onClick={() => navigate(`/group/${groupId}/settings`)}
           aria-label="Configuració del grup"
-          className="gap-2"
         >
-          <Settings className="h-4 w-4" />
-          <span>Config</span>
+          <Settings className="h-5 w-5" />
         </Button>
       </div>
 

--- a/src/features/groups/GroupDetail.tsx
+++ b/src/features/groups/GroupDetail.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useEffect, useRef, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { ArrowLeft, Plus, X, Pencil, Check, Settings, Archive, Smartphone } from 'lucide-react'
+import { ArrowLeft, Plus, X, Pencil, Check, Settings, Archive, Link2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
@@ -150,7 +150,7 @@ export function GroupDetail() {
             aria-label="Continuar en un altre dispositiu"
             title="Continuar en un altre dispositiu"
           >
-            <Smartphone className="h-5 w-5" />
+            <Link2 className="h-5 w-5" />
           </Button>
         )}
         <Button

--- a/src/features/groups/GroupDetail.tsx
+++ b/src/features/groups/GroupDetail.tsx
@@ -145,12 +145,14 @@ export function GroupDetail() {
         {!isArchived && (
           <Button
             variant="ghost"
-            size="icon"
+            size="sm"
             onClick={() => setShowSyncModal(true)}
-            aria-label="Continuar en un altre dispositiu"
-            title="Continuar en un altre dispositiu"
+            aria-label="Continua en un altre dispositiu"
+            title="Continua en un altre dispositiu"
+            className="gap-2"
           >
-            <Link2 className="h-5 w-5" />
+            <Link2 className="h-4 w-4" />
+            <span>Continua</span>
           </Button>
         )}
         <Button

--- a/src/features/groups/GroupDetail.tsx
+++ b/src/features/groups/GroupDetail.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useEffect, useRef, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { ArrowLeft, Plus, X, Pencil, Check, Settings, Archive, Link2 } from 'lucide-react'
+import { ArrowLeft, Plus, X, Pencil, Check, Settings, Archive } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
@@ -147,12 +147,10 @@ export function GroupDetail() {
             variant="ghost"
             size="sm"
             onClick={() => setShowSyncModal(true)}
-            aria-label="Continua en un altre dispositiu"
-            title="Continua en un altre dispositiu"
-            className="gap-2"
+            aria-label="Passa al mòbil"
+            title="Passa al mòbil"
           >
-            <Link2 className="h-4 w-4" />
-            <span>Continua</span>
+            Passa al mòbil
           </Button>
         )}
         <Button

--- a/src/features/groups/GroupDetail.tsx
+++ b/src/features/groups/GroupDetail.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useEffect, useRef, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { ArrowLeft, Plus, X, Pencil, Check, Settings, Archive, RefreshCw } from 'lucide-react'
+import { ArrowLeft, Plus, X, Pencil, Check, Settings, Archive, Smartphone } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
@@ -147,10 +147,10 @@ export function GroupDetail() {
             variant="ghost"
             size="icon"
             onClick={() => setShowSyncModal(true)}
-            aria-label="Sincronitzar grup"
-            title="Sincronitzar grup"
+            aria-label="Continuar en un altre dispositiu"
+            title="Continuar en un altre dispositiu"
           >
-            <RefreshCw className="h-5 w-5" />
+            <Smartphone className="h-5 w-5" />
           </Button>
         )}
         <Button

--- a/src/features/groups/GroupDetail.tsx
+++ b/src/features/groups/GroupDetail.tsx
@@ -145,21 +145,25 @@ export function GroupDetail() {
         {!isArchived && (
           <Button
             variant="ghost"
-            size="icon"
+            size="sm"
             onClick={() => setShowSyncModal(true)}
-            aria-label="Obrir o compartir en un altre dispositiu"
-            title="Obrir o compartir en un altre dispositiu"
+            aria-label="Compartir"
+            title="Compartir"
+            className="gap-2"
           >
-            <Share2 className="h-5 w-5" />
+            <Share2 className="h-4 w-4" />
+            <span>Compartir</span>
           </Button>
         )}
         <Button
           variant="ghost"
-          size="icon"
+          size="sm"
           onClick={() => navigate(`/group/${groupId}/settings`)}
           aria-label="Configuració del grup"
+          className="gap-2"
         >
-          <Settings className="h-5 w-5" />
+          <Settings className="h-4 w-4" />
+          <span>Config</span>
         </Button>
       </div>
 

--- a/src/features/groups/GroupDetail.tsx
+++ b/src/features/groups/GroupDetail.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useEffect, useRef, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { ArrowLeft, Plus, X, Pencil, Check, Settings, Archive } from 'lucide-react'
+import { ArrowLeft, Plus, X, Pencil, Check, Settings, Archive, SquareArrowUpRight } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
@@ -145,12 +145,12 @@ export function GroupDetail() {
         {!isArchived && (
           <Button
             variant="ghost"
-            size="sm"
+            size="icon"
             onClick={() => setShowSyncModal(true)}
-            aria-label="Passa al mòbil"
-            title="Passa al mòbil"
+            aria-label="Obrir o compartir en un altre dispositiu"
+            title="Obrir o compartir en un altre dispositiu"
           >
-            Passa al mòbil
+            <SquareArrowUpRight className="h-5 w-5" />
           </Button>
         )}
         <Button

--- a/src/features/groups/GroupDetail.tsx
+++ b/src/features/groups/GroupDetail.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useEffect, useRef, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { ArrowLeft, Plus, X, Pencil, Check, Settings, Archive, SquareArrowUpRight } from 'lucide-react'
+import { ArrowLeft, Plus, X, Pencil, Check, Settings, Archive, Share2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
@@ -150,7 +150,7 @@ export function GroupDetail() {
             aria-label="Obrir o compartir en un altre dispositiu"
             title="Obrir o compartir en un altre dispositiu"
           >
-            <SquareArrowUpRight className="h-5 w-5" />
+            <Share2 className="h-5 w-5" />
           </Button>
         )}
         <Button

--- a/src/features/groups/SyncFromUrl.tsx
+++ b/src/features/groups/SyncFromUrl.tsx
@@ -6,7 +6,7 @@ import {
   Loader2,
   CheckCircle2,
   AlertCircle,
-  Smartphone,
+  Link2,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
@@ -179,7 +179,7 @@ export function SyncFromUrl() {
         <Card className="shadow-md">
           <CardHeader>
             <CardTitle className="text-base flex items-center gap-2">
-              <Smartphone className="h-4 w-4" />
+              <Link2 className="h-4 w-4" />
               Connectant aquest dispositiu al grup
             </CardTitle>
             <p className="text-sm text-muted-foreground">

--- a/src/features/groups/SyncFromUrl.tsx
+++ b/src/features/groups/SyncFromUrl.tsx
@@ -6,6 +6,7 @@ import {
   Loader2,
   CheckCircle2,
   AlertCircle,
+  Smartphone,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
@@ -178,7 +179,7 @@ export function SyncFromUrl() {
         <Card className="shadow-md">
           <CardHeader>
             <CardTitle className="text-base flex items-center gap-2">
-              <RefreshCw className="h-4 w-4" />
+              <Smartphone className="h-4 w-4" />
               Connectant aquest dispositiu al grup
             </CardTitle>
             <p className="text-sm text-muted-foreground">

--- a/src/features/groups/SyncFromUrl.tsx
+++ b/src/features/groups/SyncFromUrl.tsx
@@ -6,7 +6,7 @@ import {
   Loader2,
   CheckCircle2,
   AlertCircle,
-  SquareArrowUpRight,
+  Share2,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
@@ -179,7 +179,7 @@ export function SyncFromUrl() {
         <Card className="shadow-md">
           <CardHeader>
             <CardTitle className="text-base flex items-center gap-2">
-              <SquareArrowUpRight className="h-4 w-4" />
+              <Share2 className="h-4 w-4" />
               Connectant aquest dispositiu al grup
             </CardTitle>
             <p className="text-sm text-muted-foreground">

--- a/src/features/groups/SyncFromUrl.tsx
+++ b/src/features/groups/SyncFromUrl.tsx
@@ -6,7 +6,7 @@ import {
   Loader2,
   CheckCircle2,
   AlertCircle,
-  Link2,
+  SquareArrowUpRight,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
@@ -179,7 +179,7 @@ export function SyncFromUrl() {
         <Card className="shadow-md">
           <CardHeader>
             <CardTitle className="text-base flex items-center gap-2">
-              <Link2 className="h-4 w-4" />
+              <SquareArrowUpRight className="h-4 w-4" />
               Connectant aquest dispositiu al grup
             </CardTitle>
             <p className="text-sm text-muted-foreground">

--- a/src/features/groups/SyncPanel.tsx
+++ b/src/features/groups/SyncPanel.tsx
@@ -526,7 +526,7 @@ export function SyncPanel({ groupId, embedded = false, onActiveStateChange }: Sy
             disabled={!canStart}
             className="w-full"
           >
-            <Smartphone className="h-4 w-4 mr-2" />
+            <Link2 className="h-4 w-4 mr-2" />
             Continua en un altre dispositiu
           </Button>
         )}

--- a/src/features/groups/SyncPanel.tsx
+++ b/src/features/groups/SyncPanel.tsx
@@ -526,8 +526,8 @@ export function SyncPanel({ groupId, embedded = false, onActiveStateChange }: Sy
             disabled={!canStart}
             className="w-full"
           >
-            <RefreshCw className="h-4 w-4 mr-2" />
-            Sincronitzar
+            <Smartphone className="h-4 w-4 mr-2" />
+            Continua en un altre dispositiu
           </Button>
         )}
 

--- a/src/features/groups/SyncPanel.tsx
+++ b/src/features/groups/SyncPanel.tsx
@@ -13,6 +13,7 @@ import {
   Link2,
   ShieldCheck,
   Smartphone,
+  SquareArrowUpRight,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -526,8 +527,8 @@ export function SyncPanel({ groupId, embedded = false, onActiveStateChange }: Sy
             disabled={!canStart}
             className="w-full"
           >
-            <Link2 className="h-4 w-4 mr-2" />
-            Continua en un altre dispositiu
+            <SquareArrowUpRight className="h-4 w-4 mr-2" />
+            Obrir o compartir en un altre dispositiu
           </Button>
         )}
 

--- a/src/features/groups/SyncPanel.tsx
+++ b/src/features/groups/SyncPanel.tsx
@@ -13,7 +13,7 @@ import {
   Link2,
   ShieldCheck,
   Smartphone,
-  SquareArrowUpRight,
+  Share2,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -527,7 +527,7 @@ export function SyncPanel({ groupId, embedded = false, onActiveStateChange }: Sy
             disabled={!canStart}
             className="w-full"
           >
-            <SquareArrowUpRight className="h-4 w-4 mr-2" />
+            <Share2 className="h-4 w-4 mr-2" />
             Obrir o compartir en un altre dispositiu
           </Button>
         )}


### PR DESCRIPTION
## Summary
- replace refresh-style sync entry icon with a device-oriented icon
- rename the main sync CTA to better communicate continuing on another device
- align the receiver screen heading with the same handoff framing

## Validation
- npm run build