### PR TITLE
feat: redesign group sync/share flow

### DIFF
--- a/src/features/groups/GroupDetail.tsx
+++ b/src/features/groups/GroupDetail.tsx
@@ -354,9 +354,9 @@ export function GroupDetail() {
             </div>
             <div className="mb-4 flex items-start justify-between gap-3">
               <div>
-                <h2 className="text-lg font-semibold">Sincronitzar grup</h2>
+                <h2 className="text-lg font-semibold">Compartir i sincronitzar grup</h2>
                 <p className="text-sm text-muted-foreground">
-                  Comparteix el grup amb un altre dispositiu sense sortir d&apos;aquesta vista.
+                  Connecta aquest grup amb un altre dispositiu escanejant un QR o compartint un enllaç temporal.
                 </p>
               </div>
               <Button

--- a/src/features/groups/GroupDetail.tsx
+++ b/src/features/groups/GroupDetail.tsx
@@ -346,7 +346,7 @@ export function GroupDetail() {
           }}
         >
           <div
-            className="w-full max-w-xl max-h-[85vh] overflow-y-auto rounded-t-3xl border bg-background p-4 shadow-xl sm:mb-4 sm:rounded-2xl"
+            className="w-full max-w-xl max-h-[85vh] overflow-y-auto rounded-t-3xl border bg-background p-3 shadow-xl sm:mb-4 sm:rounded-2xl"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="mb-3 flex justify-center sm:hidden">

--- a/src/features/groups/SyncPanel.tsx
+++ b/src/features/groups/SyncPanel.tsx
@@ -14,6 +14,9 @@ import {
   ShieldCheck,
   Smartphone,
   Share2,
+  QrCode,
+  LockKeyhole,
+  Power,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -290,6 +293,7 @@ function HandoffCard({
   embedded,
   sharedLinkStatus,
   linkCopied,
+  syncUrl,
   onShare,
   onCopy,
   onCancel,
@@ -298,13 +302,24 @@ function HandoffCard({
   embedded: boolean
   sharedLinkStatus: 'idle' | 'shared' | 'copied'
   linkCopied: boolean
+  syncUrl: string
   onShare: () => void
   onCopy: () => void
   onCancel: () => void
 }) {
   return (
-    <div className={`rounded-[28px] border ${embedded ? 'bg-primary/5 border-primary/20' : 'bg-muted/20'} p-4`}>
+    <div className={`rounded-[28px] border ${embedded ? 'border-primary/20 bg-primary/5' : 'bg-muted/20'} p-4`}>
       <div className="space-y-4">
+        <div className="flex items-start gap-3 rounded-2xl border bg-background/90 p-3">
+          <div className="rounded-full bg-success/10 p-2 text-success">
+            <CheckCircle2 className="h-4 w-4" />
+          </div>
+          <div className="space-y-1">
+            <p className="text-sm font-semibold text-foreground">Sincronització activa</p>
+            <p className="text-sm text-muted-foreground">Enllaç actiu durant aquesta sessió per connectar un altre dispositiu.</p>
+          </div>
+        </div>
+
         <div className="mx-auto w-full max-w-[320px] rounded-[28px] border bg-white p-2 shadow-sm sm:max-w-[360px]">
           {qrMarkup ? (
             <div
@@ -320,12 +335,19 @@ function HandoffCard({
 
         <div className="space-y-1 text-center">
           <p className="text-base font-semibold text-foreground">Escaneja el QR a l’altre dispositiu</p>
-          <p className="text-sm text-muted-foreground">Si no pots escanejar-lo, comparteix l’enllaç o copia’l.</p>
+          <p className="text-sm text-muted-foreground">També pots compartir o copiar l’enllaç si tens els dos dispositius a mà.</p>
+        </div>
+
+        <div className="rounded-2xl border bg-background p-3">
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Link2 className="h-4 w-4" />
+            <span className="truncate">{syncUrl.replace(/^https?:\/\//, '')}</span>
+          </div>
         </div>
 
         <div className="space-y-2">
           <Button onClick={onShare} className="w-full">
-            {sharedLinkStatus !== 'idle' ? <Check className="mr-2 h-4 w-4" /> : <Link2 className="mr-2 h-4 w-4" />}
+            {sharedLinkStatus !== 'idle' ? <Check className="mr-2 h-4 w-4" /> : <Share2 className="mr-2 h-4 w-4" />}
             {sharedLinkStatus === 'shared' ? 'Enllaç compartit!' : sharedLinkStatus === 'copied' ? 'Enllaç copiat!' : 'Compartir enllaç'}
           </Button>
 
@@ -334,8 +356,20 @@ function HandoffCard({
             {linkCopied ? 'Enllaç copiat' : 'Copiar enllaç'}
           </Button>
 
+          <div className="rounded-2xl border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-950 dark:border-emerald-900/40 dark:bg-emerald-950/30 dark:text-emerald-100">
+            <div className="mb-1 flex items-center gap-2 font-medium">
+              <ShieldCheck className="h-4 w-4" />
+              <span>Privat per disseny</span>
+            </div>
+            <ul className="space-y-1 text-sm text-emerald-900/80 dark:text-emerald-100/80">
+              <li>• L’enllaç només obre la connexió entre dispositius.</li>
+              <li>• Les dades viatgen xifrades amb la contrasenya del grup.</li>
+              <li>• L’enllaç actiu caduca en acabar aquesta sessió.</li>
+            </ul>
+          </div>
+
           <Button type="button" variant="ghost" onClick={onCancel} className="w-full text-muted-foreground">
-            Cancel·lar
+            Desactivar sincronització
           </Button>
         </div>
       </div>
@@ -455,88 +489,107 @@ export function SyncPanel({ groupId, embedded = false, onActiveStateChange }: Sy
   const content = (
     <div className="space-y-4">
       {showSetupCopy && !hideSetupWhileWaiting && (
-        <div className="space-y-3 rounded-2xl border bg-muted/20 p-4">
-          <div className="flex items-start gap-3">
-            <div className="rounded-full bg-primary/10 p-2 text-primary">
-              <Smartphone className="h-4 w-4" />
+        <div className="space-y-4">
+          <div className="rounded-3xl border bg-muted/20 p-4">
+            <div className="flex items-start gap-3">
+              <div className="rounded-full bg-primary/10 p-2 text-primary">
+                <Smartphone className="h-4 w-4" />
+              </div>
+              <div className="space-y-1">
+                <p className="font-medium">Sincronitzar grup</p>
+                <p className="text-sm text-muted-foreground">
+                  Activa la sincronització per mantenir aquest grup actualitzat en tots els dispositius.
+                </p>
+              </div>
             </div>
-            <div className="space-y-1">
-              <p className="font-medium">Passa aquest grup a un altre dispositiu</p>
-              <p className="text-sm text-muted-foreground">
-                Flux curt: poses la contrasenya, toques sincronitzar i ensenyes el QR o comparteixes l’enllaç.
+
+            <div className="mt-4 rounded-2xl border bg-background p-4">
+              <div className="flex items-start gap-3">
+                <div className="rounded-full bg-muted p-2 text-muted-foreground">
+                  <Power className="h-4 w-4" />
+                </div>
+                <div className="space-y-1">
+                  <p className="font-medium">Sincronització desactivada</p>
+                  <p className="text-sm text-muted-foreground">Cap dispositiu connectat.</p>
+                </div>
+              </div>
+            </div>
+
+            <div className="mt-4 space-y-1.5">
+              <Label htmlFor="sync-passphrase">Contrasenya del grup</Label>
+              <div className="flex gap-2">
+                <div className="relative flex-1">
+                  <Input
+                    id="sync-passphrase"
+                    type={showPassphrase ? 'text' : 'password'}
+                    value={passphrase}
+                    onChange={(e) => setPassphrase(e.target.value)}
+                    onBlur={() => {
+                      void persistPassphrase(passphrase)
+                    }}
+                    placeholder="Mínim 4 caràcters"
+                    disabled={isActive}
+                    autoComplete="new-password"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowPassphrase(!showPassphrase)}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground transition-colors hover:text-foreground"
+                    aria-label={showPassphrase ? 'Amagar contrasenya' : 'Mostrar contrasenya'}
+                  >
+                    {showPassphrase ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                  </button>
+                </div>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Aquesta contrasenya xifra i protegeix les dades del grup mentre es sincronitzen entre dispositius.
               </p>
             </div>
-          </div>
 
-          <div className="rounded-xl border bg-background p-3 text-sm text-muted-foreground">
-            <div className="mb-2 flex items-center gap-2 text-foreground">
-              <ShieldCheck className="h-4 w-4 text-success" />
-              <span className="font-medium">Privat per disseny</span>
+            <div className="mt-4 rounded-2xl bg-primary/5 p-4">
+              <p className="mb-2 text-sm font-medium">Com funciona?</p>
+              <div className="space-y-2 text-sm text-muted-foreground">
+                <div className="flex items-start gap-2">
+                  <span className="mt-0.5 inline-flex h-5 w-5 items-center justify-center rounded-full bg-primary/15 text-xs font-semibold text-primary">1</span>
+                  <span>Actives la sincronització</span>
+                </div>
+                <div className="flex items-start gap-2">
+                  <span className="mt-0.5 inline-flex h-5 w-5 items-center justify-center rounded-full bg-primary/15 text-xs font-semibold text-primary">2</span>
+                  <span>Comparteixes el QR o l’enllaç generat</span>
+                </div>
+                <div className="flex items-start gap-2">
+                  <span className="mt-0.5 inline-flex h-5 w-5 items-center justify-center rounded-full bg-primary/15 text-xs font-semibold text-primary">3</span>
+                  <span>Els dispositius es mantenen sincronitzats en temps real</span>
+                </div>
+              </div>
             </div>
-            <p>
-              L'enllaç només serveix per obrir la connexió entre dispositius. Les dades del grup viatgen protegides amb la contrasenya del grup.
-            </p>
+
+            {sync.state === 'idle' && (
+              <Button
+                onClick={async () => {
+                  setMode('host')
+                  try {
+                    await persistPassphrase(passphrase)
+                    await sync.startSync()
+                  } catch {
+                    // Error is handled by the sync hook
+                  }
+                }}
+                disabled={!canStart}
+                className="mt-4 w-full"
+              >
+                <QrCode className="mr-2 h-4 w-4" />
+                Activar sincronització
+              </Button>
+            )}
+
+            <div className="mt-3 flex items-center justify-center gap-2 text-xs text-muted-foreground">
+              <LockKeyhole className="h-3.5 w-3.5" />
+              <span>Privat per disseny. Sense núvol, sense comptes.</span>
+            </div>
           </div>
         </div>
       )}
-
-        {!hideSetupWhileWaiting && (
-          <div className="space-y-1.5">
-            <Label htmlFor="sync-passphrase">Contrasenya del grup</Label>
-            <div className="flex gap-2">
-              <div className="relative flex-1">
-                <Input
-                  id="sync-passphrase"
-                  type={showPassphrase ? 'text' : 'password'}
-                  value={passphrase}
-                  onChange={(e) => setPassphrase(e.target.value)}
-                  onBlur={() => {
-                    void persistPassphrase(passphrase)
-                  }}
-                  placeholder="Mínim 4 caràcters"
-                  disabled={isActive}
-                  autoComplete="new-password"
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowPassphrase(!showPassphrase)}
-                  className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-                  aria-label={showPassphrase ? 'Amagar contrasenya' : 'Mostrar contrasenya'}
-                >
-                  {showPassphrase ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                </button>
-              </div>
-            </div>
-            <p className="text-xs text-muted-foreground">
-              Aquesta contrasenya es guarda al grup i en aquest dispositiu perquè no l'hagis d'escriure cada vegada.
-            </p>
-          </div>
-        )}
-
-        {sync.state === 'idle' && (
-          <Button
-            onClick={async () => {
-              setMode('host')
-              try {
-                await persistPassphrase(passphrase)
-                await sync.startSync()
-              } catch {
-                // Error is handled by the sync hook
-              }
-            }}
-            disabled={!canStart}
-            className="w-full"
-          >
-            <Share2 className="h-4 w-4 mr-2" />
-            Obrir o compartir en un altre dispositiu
-          </Button>
-        )}
-
-        {showSetupCopy && !hideSetupWhileWaiting && (
-          <div className="rounded-xl border border-dashed bg-background/70 px-3 py-2 text-xs text-muted-foreground">
-            1. Escriu la contrasenya del grup · 2. Toca sincronitzar · 3. Escaneja el QR o obre l’enllaç a l’altre dispositiu
-          </div>
-        )}
 
         {/* Active sync status */}
         {sync.state !== 'idle' && (
@@ -598,6 +651,7 @@ export function SyncPanel({ groupId, embedded = false, onActiveStateChange }: Sy
                 embedded={embedded}
                 sharedLinkStatus={sharedLinkStatus}
                 linkCopied={linkCopied}
+                syncUrl={syncUrl}
                 onShare={() => {
                   void handleCopySyncLink()
                 }}

--- a/src/features/groups/SyncPanel.tsx
+++ b/src/features/groups/SyncPanel.tsx
@@ -479,104 +479,100 @@ export function SyncPanel({ groupId, embedded = false, onActiveStateChange }: Sy
   const content = (
     <div className="space-y-4">
       {showSetupCopy && !hideSetupWhileWaiting && (
-        <div className="space-y-4">
-          <div className="rounded-3xl border bg-muted/20 p-4">
-            <div className="flex items-start gap-3">
-              <div className="rounded-full bg-primary/10 p-2 text-primary">
-                <Smartphone className="h-4 w-4" />
-              </div>
-              <div className="space-y-1">
-                <p className="font-medium">Sincronitzar grup</p>
-                <p className="text-sm text-muted-foreground">
-                  Activa la sincronització per mantenir aquest grup actualitzat en tots els dispositius.
-                </p>
-              </div>
+        <div className="space-y-4 px-1">
+          <div className="flex items-start gap-3">
+            <div className="rounded-full bg-primary/10 p-2 text-primary">
+              <Smartphone className="h-4 w-4" />
             </div>
-
-            <div className="mt-3 rounded-2xl border bg-background p-3.5">
-              <div className="flex items-start gap-3">
-                <div className="rounded-full bg-muted p-2 text-muted-foreground">
-                  <Power className="h-4 w-4" />
-                </div>
-                <div className="space-y-1">
-                  <p className="font-medium">Sincronització desactivada</p>
-                  <p className="text-sm text-muted-foreground">Cap dispositiu connectat.</p>
-                </div>
-              </div>
-            </div>
-
-            <div className="mt-3 space-y-1.5">
-              <Label htmlFor="sync-passphrase">Contrasenya del grup</Label>
-              <div className="flex gap-2">
-                <div className="relative flex-1">
-                  <Input
-                    id="sync-passphrase"
-                    type={showPassphrase ? 'text' : 'password'}
-                    value={passphrase}
-                    onChange={(e) => setPassphrase(e.target.value)}
-                    onBlur={() => {
-                      void persistPassphrase(passphrase)
-                    }}
-                    placeholder="Mínim 4 caràcters"
-                    disabled={isActive}
-                    autoComplete="new-password"
-                  />
-                  <button
-                    type="button"
-                    onClick={() => setShowPassphrase(!showPassphrase)}
-                    className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground transition-colors hover:text-foreground"
-                    aria-label={showPassphrase ? 'Amagar contrasenya' : 'Mostrar contrasenya'}
-                  >
-                    {showPassphrase ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                  </button>
-                </div>
-              </div>
-              <p className="text-xs text-muted-foreground">
-                Aquesta contrasenya xifra i protegeix les dades del grup mentre es sincronitzen entre dispositius.
+            <div className="space-y-1">
+              <p className="font-medium">Sincronitzar grup</p>
+              <p className="text-sm text-muted-foreground">
+                Activa la sincronització per mantenir aquest grup actualitzat en tots els dispositius.
               </p>
             </div>
+          </div>
 
-            <div className="mt-3 rounded-2xl bg-primary/5 p-3.5">
-              <p className="mb-2 text-sm font-medium">Com funciona?</p>
-              <div className="space-y-2 text-sm text-muted-foreground">
-                <div className="flex items-start gap-2">
-                  <span className="mt-0.5 inline-flex h-5 w-5 items-center justify-center rounded-full bg-primary/15 text-xs font-semibold text-primary">1</span>
-                  <span>Actives la sincronització</span>
-                </div>
-                <div className="flex items-start gap-2">
-                  <span className="mt-0.5 inline-flex h-5 w-5 items-center justify-center rounded-full bg-primary/15 text-xs font-semibold text-primary">2</span>
-                  <span>Comparteixes el QR o l’enllaç generat</span>
-                </div>
-                <div className="flex items-start gap-2">
-                  <span className="mt-0.5 inline-flex h-5 w-5 items-center justify-center rounded-full bg-primary/15 text-xs font-semibold text-primary">3</span>
-                  <span>L’altre dispositiu entra directament al grup</span>
-                </div>
+          <div className="flex items-start gap-3 rounded-2xl bg-background/70 px-4 py-3">
+            <div className="rounded-full bg-muted p-2 text-muted-foreground">
+              <Power className="h-4 w-4" />
+            </div>
+            <div className="space-y-1">
+              <p className="font-medium">Sincronització desactivada</p>
+              <p className="text-sm text-muted-foreground">Cap dispositiu connectat.</p>
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="sync-passphrase">Contrasenya del grup</Label>
+            <div className="flex gap-2">
+              <div className="relative flex-1">
+                <Input
+                  id="sync-passphrase"
+                  type={showPassphrase ? 'text' : 'password'}
+                  value={passphrase}
+                  onChange={(e) => setPassphrase(e.target.value)}
+                  onBlur={() => {
+                    void persistPassphrase(passphrase)
+                  }}
+                  placeholder="Mínim 4 caràcters"
+                  disabled={isActive}
+                  autoComplete="new-password"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassphrase(!showPassphrase)}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground transition-colors hover:text-foreground"
+                  aria-label={showPassphrase ? 'Amagar contrasenya' : 'Mostrar contrasenya'}
+                >
+                  {showPassphrase ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                </button>
               </div>
             </div>
+            <p className="text-xs text-muted-foreground">
+              Aquesta contrasenya xifra i protegeix les dades del grup mentre es sincronitzen entre dispositius.
+            </p>
+          </div>
 
-            {sync.state === 'idle' && (
-              <Button
-                onClick={async () => {
-                  setMode('host')
-                  try {
-                    await persistPassphrase(passphrase)
-                    await sync.startSync()
-                  } catch {
-                    // Error is handled by the sync hook
-                  }
-                }}
-                disabled={!canStart}
-                className="mt-3 w-full"
-              >
-                <QrCode className="mr-2 h-4 w-4" />
-                Activar sincronització
-              </Button>
-            )}
-
-            <div className="mt-2.5 flex items-center justify-center gap-2 text-xs text-muted-foreground">
-              <LockKeyhole className="h-3.5 w-3.5" />
-              <span>Privat per disseny. Sense núvol, sense comptes.</span>
+          <div className="space-y-2 pt-1">
+            <p className="text-sm font-medium">Com funciona?</p>
+            <div className="space-y-2 text-sm text-muted-foreground">
+              <div className="flex items-start gap-2.5">
+                <span className="mt-0.5 inline-flex h-5 w-5 items-center justify-center rounded-full bg-muted text-xs font-semibold text-foreground">1</span>
+                <span>Actives la sincronització</span>
+              </div>
+              <div className="flex items-start gap-2.5">
+                <span className="mt-0.5 inline-flex h-5 w-5 items-center justify-center rounded-full bg-muted text-xs font-semibold text-foreground">2</span>
+                <span>Comparteixes el QR o l’enllaç generat</span>
+              </div>
+              <div className="flex items-start gap-2.5">
+                <span className="mt-0.5 inline-flex h-5 w-5 items-center justify-center rounded-full bg-muted text-xs font-semibold text-foreground">3</span>
+                <span>L’altre dispositiu entra directament al grup</span>
+              </div>
             </div>
+          </div>
+
+          {sync.state === 'idle' && (
+            <Button
+              onClick={async () => {
+                setMode('host')
+                try {
+                  await persistPassphrase(passphrase)
+                  await sync.startSync()
+                } catch {
+                  // Error is handled by the sync hook
+                }
+              }}
+              disabled={!canStart}
+              className="w-full rounded-2xl"
+            >
+              <QrCode className="mr-2 h-4 w-4" />
+              Activar sincronització
+            </Button>
+          )}
+
+          <div className="flex items-center justify-center gap-2 pt-1 text-xs text-muted-foreground">
+            <LockKeyhole className="h-3.5 w-3.5" />
+            <span>Privat per disseny. Sense núvol, sense comptes.</span>
           </div>
         </div>
       )}

--- a/src/features/groups/SyncPanel.tsx
+++ b/src/features/groups/SyncPanel.tsx
@@ -308,69 +308,71 @@ function HandoffCard({
   onCancel: () => void
 }) {
   return (
-    <div className={`rounded-[28px] border ${embedded ? 'border-primary/20 bg-primary/5' : 'bg-muted/20'} p-4`}>
-      <div className="space-y-4">
+    <div className={`rounded-[24px] border ${embedded ? 'border-primary/20 bg-primary/5' : 'bg-muted/20'} p-3`}>
+      <div className="space-y-3">
         <div className="flex items-start gap-3 rounded-2xl border bg-background/90 p-3">
           <div className="rounded-full bg-success/10 p-2 text-success">
             <CheckCircle2 className="h-4 w-4" />
           </div>
           <div className="space-y-1">
             <p className="text-sm font-semibold text-foreground">Sincronització activa</p>
-            <p className="text-sm text-muted-foreground">Enllaç actiu durant aquesta sessió per connectar un altre dispositiu.</p>
+            <p className="text-xs leading-5 text-muted-foreground">Escaneja el QR o obre l’enllaç en l’altre dispositiu.</p>
           </div>
         </div>
 
-        <div className="mx-auto w-full max-w-[320px] rounded-[28px] border bg-white p-2 shadow-sm sm:max-w-[360px]">
-          {qrMarkup ? (
-            <div
-              className="qr-frame aspect-square w-full overflow-hidden rounded-[24px] bg-white"
-              dangerouslySetInnerHTML={{ __html: qrMarkup }}
-            />
-          ) : (
-            <div className="flex aspect-square w-full items-center justify-center rounded-[24px] bg-muted px-6 text-center text-xs text-muted-foreground">
-              Preparant el QR…
+        <div className="grid gap-3 sm:grid-cols-[minmax(0,188px)_minmax(0,1fr)] sm:items-start">
+          <div className="mx-auto w-full max-w-[188px] rounded-[24px] border bg-white p-2 shadow-sm">
+            {qrMarkup ? (
+              <div
+                className="qr-frame aspect-square w-full overflow-hidden rounded-[18px] bg-white"
+                dangerouslySetInnerHTML={{ __html: qrMarkup }}
+              />
+            ) : (
+              <div className="flex aspect-square w-full items-center justify-center rounded-[18px] bg-muted px-4 text-center text-xs text-muted-foreground">
+                Preparant el QR…
+              </div>
+            )}
+          </div>
+
+          <div className="space-y-3">
+            <div className="space-y-1">
+              <p className="text-sm font-semibold text-foreground">Escaneja el QR</p>
+              <p className="text-xs leading-5 text-muted-foreground">Si no et va bé, comparteix o copia l’enllaç temporal.</p>
             </div>
-          )}
-        </div>
 
-        <div className="space-y-1 text-center">
-          <p className="text-base font-semibold text-foreground">Escaneja el QR a l’altre dispositiu</p>
-          <p className="text-sm text-muted-foreground">També pots compartir o copiar l’enllaç si tens els dos dispositius a mà.</p>
-        </div>
-
-        <div className="rounded-2xl border bg-background p-3">
-          <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            <Link2 className="h-4 w-4" />
-            <span className="truncate">{syncUrl.replace(/^https?:\/\//, '')}</span>
-          </div>
-        </div>
-
-        <div className="space-y-2">
-          <Button onClick={onShare} className="w-full">
-            {sharedLinkStatus !== 'idle' ? <Check className="mr-2 h-4 w-4" /> : <Share2 className="mr-2 h-4 w-4" />}
-            {sharedLinkStatus === 'shared' ? 'Enllaç compartit!' : sharedLinkStatus === 'copied' ? 'Enllaç copiat!' : 'Compartir enllaç'}
-          </Button>
-
-          <Button type="button" variant="outline" onClick={onCopy} className="w-full">
-            {linkCopied ? <Check className="mr-2 h-4 w-4" /> : <Copy className="mr-2 h-4 w-4" />}
-            {linkCopied ? 'Enllaç copiat' : 'Copiar enllaç'}
-          </Button>
-
-          <div className="rounded-2xl border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-950 dark:border-emerald-900/40 dark:bg-emerald-950/30 dark:text-emerald-100">
-            <div className="mb-1 flex items-center gap-2 font-medium">
-              <ShieldCheck className="h-4 w-4" />
-              <span>Privat per disseny</span>
+            <div className="rounded-2xl border bg-background px-3 py-2.5">
+              <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                <Link2 className="h-3.5 w-3.5 shrink-0" />
+                <span className="truncate">{syncUrl.replace(/^https?:\/\//, '')}</span>
+              </div>
             </div>
-            <ul className="space-y-1 text-sm text-emerald-900/80 dark:text-emerald-100/80">
-              <li>• L’enllaç només obre la connexió entre dispositius.</li>
-              <li>• Les dades viatgen xifrades amb la contrasenya del grup.</li>
-              <li>• L’enllaç actiu caduca en acabar aquesta sessió.</li>
-            </ul>
-          </div>
 
-          <Button type="button" variant="ghost" onClick={onCancel} className="w-full text-muted-foreground">
-            Desactivar sincronització
-          </Button>
+            <div className="grid gap-2 sm:grid-cols-2">
+              <Button onClick={onShare} className="w-full">
+                {sharedLinkStatus !== 'idle' ? <Check className="mr-2 h-4 w-4" /> : <Share2 className="mr-2 h-4 w-4" />}
+                {sharedLinkStatus === 'shared' ? 'Compartit' : sharedLinkStatus === 'copied' ? 'Copiat' : 'Compartir'}
+              </Button>
+
+              <Button type="button" variant="outline" onClick={onCopy} className="w-full">
+                {linkCopied ? <Check className="mr-2 h-4 w-4" /> : <Copy className="mr-2 h-4 w-4" />}
+                {linkCopied ? 'Copiat' : 'Copiar'}
+              </Button>
+            </div>
+
+            <div className="rounded-2xl border border-emerald-200 bg-emerald-50 px-3 py-2.5 text-xs text-emerald-950 dark:border-emerald-900/40 dark:bg-emerald-950/30 dark:text-emerald-100">
+              <div className="flex items-center gap-2 font-medium">
+                <ShieldCheck className="h-3.5 w-3.5" />
+                <span>Privat per disseny</span>
+              </div>
+              <p className="mt-1 leading-5 text-emerald-900/80 dark:text-emerald-100/80">
+                Enllaç temporal. Dades xifrades amb la contrasenya del grup.
+              </p>
+            </div>
+
+            <Button type="button" variant="ghost" onClick={onCancel} className="h-9 justify-start px-0 text-xs text-muted-foreground hover:bg-transparent">
+              Desactivar sincronització
+            </Button>
+          </div>
         </div>
       </div>
     </div>
@@ -420,7 +422,7 @@ export function SyncPanel({ groupId, embedded = false, onActiveStateChange }: Sy
       return
     }
 
-    createQrSvg(syncUrl, 220)
+    createQrSvg(syncUrl, 176)
       .then((svg) => {
         if (!cancelled) setQrMarkup(svg)
       })
@@ -503,7 +505,7 @@ export function SyncPanel({ groupId, embedded = false, onActiveStateChange }: Sy
               </div>
             </div>
 
-            <div className="mt-4 rounded-2xl border bg-background p-4">
+            <div className="mt-3 rounded-2xl border bg-background p-3.5">
               <div className="flex items-start gap-3">
                 <div className="rounded-full bg-muted p-2 text-muted-foreground">
                   <Power className="h-4 w-4" />
@@ -515,7 +517,7 @@ export function SyncPanel({ groupId, embedded = false, onActiveStateChange }: Sy
               </div>
             </div>
 
-            <div className="mt-4 space-y-1.5">
+            <div className="mt-3 space-y-1.5">
               <Label htmlFor="sync-passphrase">Contrasenya del grup</Label>
               <div className="flex gap-2">
                 <div className="relative flex-1">
@@ -546,7 +548,7 @@ export function SyncPanel({ groupId, embedded = false, onActiveStateChange }: Sy
               </p>
             </div>
 
-            <div className="mt-4 rounded-2xl bg-primary/5 p-4">
+            <div className="mt-3 rounded-2xl bg-primary/5 p-3.5">
               <p className="mb-2 text-sm font-medium">Com funciona?</p>
               <div className="space-y-2 text-sm text-muted-foreground">
                 <div className="flex items-start gap-2">
@@ -559,7 +561,7 @@ export function SyncPanel({ groupId, embedded = false, onActiveStateChange }: Sy
                 </div>
                 <div className="flex items-start gap-2">
                   <span className="mt-0.5 inline-flex h-5 w-5 items-center justify-center rounded-full bg-primary/15 text-xs font-semibold text-primary">3</span>
-                  <span>Els dispositius es mantenen sincronitzats en temps real</span>
+                  <span>L’altre dispositiu entra directament al grup</span>
                 </div>
               </div>
             </div>
@@ -576,14 +578,14 @@ export function SyncPanel({ groupId, embedded = false, onActiveStateChange }: Sy
                   }
                 }}
                 disabled={!canStart}
-                className="mt-4 w-full"
+                className="mt-3 w-full"
               >
                 <QrCode className="mr-2 h-4 w-4" />
                 Activar sincronització
               </Button>
             )}
 
-            <div className="mt-3 flex items-center justify-center gap-2 text-xs text-muted-foreground">
+            <div className="mt-2.5 flex items-center justify-center gap-2 text-xs text-muted-foreground">
               <LockKeyhole className="h-3.5 w-3.5" />
               <span>Privat per disseny. Sense núvol, sense comptes.</span>
             </div>

--- a/src/features/groups/SyncPanel.tsx
+++ b/src/features/groups/SyncPanel.tsx
@@ -479,31 +479,31 @@ export function SyncPanel({ groupId, embedded = false, onActiveStateChange }: Sy
   const content = (
     <div className="space-y-4">
       {showSetupCopy && !hideSetupWhileWaiting && (
-        <div className="space-y-4 px-1">
+        <div className="space-y-5 px-1">
           <div className="flex items-start gap-3">
             <div className="rounded-full bg-primary/10 p-2 text-primary">
               <Smartphone className="h-4 w-4" />
             </div>
             <div className="space-y-1">
-              <p className="font-medium">Sincronitzar grup</p>
-              <p className="text-sm text-muted-foreground">
+              <p className="text-[1.05rem] font-semibold">Sincronitzar grup</p>
+              <p className="text-sm leading-6 text-muted-foreground">
                 Activa la sincronització per mantenir aquest grup actualitzat en tots els dispositius.
               </p>
             </div>
           </div>
 
-          <div className="flex items-start gap-3 rounded-2xl bg-background/70 px-4 py-3">
+          <div className="flex items-start gap-3 px-1 py-1">
             <div className="rounded-full bg-muted p-2 text-muted-foreground">
               <Power className="h-4 w-4" />
             </div>
             <div className="space-y-1">
-              <p className="font-medium">Sincronització desactivada</p>
+              <p className="text-[1.05rem] font-semibold">Sincronització desactivada</p>
               <p className="text-sm text-muted-foreground">Cap dispositiu connectat.</p>
             </div>
           </div>
 
-          <div className="space-y-1.5">
-            <Label htmlFor="sync-passphrase">Contrasenya del grup</Label>
+          <div className="space-y-2">
+            <Label htmlFor="sync-passphrase" className="text-base font-semibold">Contrasenya del grup</Label>
             <div className="flex gap-2">
               <div className="relative flex-1">
                 <Input
@@ -517,34 +517,35 @@ export function SyncPanel({ groupId, embedded = false, onActiveStateChange }: Sy
                   placeholder="Mínim 4 caràcters"
                   disabled={isActive}
                   autoComplete="new-password"
+                  className="h-12 rounded-2xl"
                 />
                 <button
                   type="button"
                   onClick={() => setShowPassphrase(!showPassphrase)}
-                  className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground transition-colors hover:text-foreground"
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground transition-colors hover:text-foreground"
                   aria-label={showPassphrase ? 'Amagar contrasenya' : 'Mostrar contrasenya'}
                 >
                   {showPassphrase ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
                 </button>
               </div>
             </div>
-            <p className="text-xs text-muted-foreground">
+            <p className="text-xs leading-5 text-muted-foreground">
               Aquesta contrasenya xifra i protegeix les dades del grup mentre es sincronitzen entre dispositius.
             </p>
           </div>
 
-          <div className="space-y-2 pt-1">
-            <p className="text-sm font-medium">Com funciona?</p>
-            <div className="space-y-2 text-sm text-muted-foreground">
-              <div className="flex items-start gap-2.5">
+          <div className="space-y-3">
+            <p className="text-base font-semibold">Com funciona?</p>
+            <div className="space-y-3 text-sm text-muted-foreground">
+              <div className="flex items-start gap-3">
                 <span className="mt-0.5 inline-flex h-5 w-5 items-center justify-center rounded-full bg-muted text-xs font-semibold text-foreground">1</span>
                 <span>Actives la sincronització</span>
               </div>
-              <div className="flex items-start gap-2.5">
+              <div className="flex items-start gap-3">
                 <span className="mt-0.5 inline-flex h-5 w-5 items-center justify-center rounded-full bg-muted text-xs font-semibold text-foreground">2</span>
                 <span>Comparteixes el QR o l’enllaç generat</span>
               </div>
-              <div className="flex items-start gap-2.5">
+              <div className="flex items-start gap-3">
                 <span className="mt-0.5 inline-flex h-5 w-5 items-center justify-center rounded-full bg-muted text-xs font-semibold text-foreground">3</span>
                 <span>L’altre dispositiu entra directament al grup</span>
               </div>
@@ -563,7 +564,7 @@ export function SyncPanel({ groupId, embedded = false, onActiveStateChange }: Sy
                 }
               }}
               disabled={!canStart}
-              className="w-full rounded-2xl"
+              className="h-12 w-full rounded-2xl"
             >
               <QrCode className="mr-2 h-4 w-4" />
               Activar sincronització

--- a/src/features/groups/SyncPanel.tsx
+++ b/src/features/groups/SyncPanel.tsx
@@ -308,70 +308,60 @@ function HandoffCard({
   onCancel: () => void
 }) {
   return (
-    <div className={`rounded-[28px] ${embedded ? 'bg-primary/5' : 'bg-muted/20'} px-4 py-4 sm:px-5`}>
-      <div className="space-y-4">
-        <div className="flex items-start gap-3">
-          <div className="mt-0.5 rounded-full bg-success/10 p-2 text-success">
+    <div className={`${embedded ? 'bg-primary/5' : 'bg-muted/15'} px-2 py-2 sm:px-3`}>
+      <div className="mx-auto flex max-w-[280px] flex-col items-center text-center">
+        <div className="mb-3 flex items-center gap-2 self-start text-sm font-semibold text-foreground">
+          <div className="rounded-full bg-success/10 p-1.5 text-success">
             <CheckCircle2 className="h-4 w-4" />
           </div>
-          <div className="min-w-0 space-y-1">
-            <p className="text-sm font-semibold text-foreground">Sincronització activa</p>
-            <p className="text-sm leading-5 text-muted-foreground">Escaneja aquest QR a l’altre dispositiu o obre-hi l’enllaç temporal.</p>
-          </div>
+          <span>Sincronització activa</span>
         </div>
 
-        <div className="flex flex-col items-center text-center">
-          <div className="w-full max-w-[208px] bg-white p-2 shadow-sm ring-1 ring-black/10 rounded-[24px]">
-            {qrMarkup ? (
-              <div
-                className="qr-frame aspect-square w-full overflow-hidden rounded-[18px] bg-white"
-                dangerouslySetInnerHTML={{ __html: qrMarkup }}
-              />
-            ) : (
-              <div className="flex aspect-square w-full items-center justify-center rounded-[18px] bg-muted px-4 text-center text-xs text-muted-foreground">
-                Preparant el QR…
-              </div>
-            )}
-          </div>
-
-          <div className="mt-3 space-y-1">
-            <p className="text-base font-semibold text-foreground">Escaneja el QR</p>
-            <p className="text-sm leading-5 text-muted-foreground">Si no et va bé, comparteix o copia l’enllaç temporal.</p>
-          </div>
-        </div>
-
-        <div className="space-y-2.5">
-          <div className="bg-background/80 px-3 py-2.5 rounded-2xl">
-            <div className="flex items-center gap-2 text-xs text-muted-foreground">
-              <Link2 className="h-3.5 w-3.5 shrink-0" />
-              <span className="truncate">{syncUrl.replace(/^https?:\/\//, '')}</span>
+        <div className="w-full rounded-[28px] bg-white p-3 shadow-[0_10px_30px_rgba(15,23,42,0.08)]">
+          {qrMarkup ? (
+            <div
+              className="qr-frame aspect-square w-full overflow-hidden rounded-[24px] bg-white"
+              dangerouslySetInnerHTML={{ __html: qrMarkup }}
+            />
+          ) : (
+            <div className="flex aspect-square w-full items-center justify-center rounded-[24px] bg-muted px-4 text-center text-xs text-muted-foreground">
+              Preparant el QR…
             </div>
-          </div>
+          )}
+        </div>
 
-          <Button onClick={onShare} className="w-full shadow-sm">
+        <div className="mt-4 space-y-1">
+          <p className="text-lg font-semibold text-foreground">Escaneja el QR</p>
+          <p className="text-sm leading-5 text-muted-foreground">Obre aquest grup a l’altre dispositiu amb el QR o amb l’enllaç temporal.</p>
+        </div>
+
+        <div className="mt-4 w-full space-y-2">
+          <Button onClick={onShare} className="h-11 w-full rounded-2xl shadow-sm">
             {sharedLinkStatus !== 'idle' ? <Check className="mr-2 h-4 w-4" /> : <Share2 className="mr-2 h-4 w-4" />}
             {sharedLinkStatus === 'shared' ? 'Enllaç compartit' : sharedLinkStatus === 'copied' ? 'Enllaç copiat' : 'Compartir enllaç'}
           </Button>
 
-          <Button type="button" variant="outline" onClick={onCopy} className="w-full bg-background/90">
+          <Button type="button" variant="outline" onClick={onCopy} className="h-11 w-full rounded-2xl bg-background/90">
             {linkCopied ? <Check className="mr-2 h-4 w-4" /> : <Copy className="mr-2 h-4 w-4" />}
             {linkCopied ? 'Enllaç copiat' : 'Copiar enllaç'}
           </Button>
-
-          <div className="bg-emerald-50/80 px-3 py-2.5 rounded-2xl text-left text-xs text-emerald-950 dark:bg-emerald-950/30 dark:text-emerald-100">
-            <div className="flex items-center gap-2 font-medium">
-              <ShieldCheck className="h-3.5 w-3.5" />
-              <span>Privat per disseny</span>
-            </div>
-            <p className="mt-1 leading-5 text-emerald-900/80 dark:text-emerald-100/80">
-              Enllaç temporal. Dades xifrades amb la contrasenya del grup.
-            </p>
-          </div>
-
-          <Button type="button" variant="ghost" onClick={onCancel} className="h-9 w-full text-xs text-muted-foreground hover:bg-transparent">
-            Desactivar sincronització
-          </Button>
         </div>
+
+        <div className="mt-3 w-full text-left">
+          <div className="flex items-start gap-2 text-xs text-muted-foreground">
+            <Link2 className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+            <span className="truncate">{syncUrl.replace(/^https?:\/\//, '')}</span>
+          </div>
+        </div>
+
+        <div className="mt-4 flex w-full items-start gap-2 text-left text-xs text-muted-foreground">
+          <ShieldCheck className="mt-0.5 h-3.5 w-3.5 shrink-0 text-success" />
+          <p className="leading-5">Privat per disseny. Enllaç temporal i dades xifrades amb la contrasenya del grup.</p>
+        </div>
+
+        <Button type="button" variant="ghost" onClick={onCancel} className="mt-3 h-9 px-0 text-xs text-muted-foreground hover:bg-transparent">
+          Desactivar sincronització
+        </Button>
       </div>
     </div>
   )
@@ -420,7 +410,7 @@ export function SyncPanel({ groupId, embedded = false, onActiveStateChange }: Sy
       return
     }
 
-    createQrSvg(syncUrl, 176)
+    createQrSvg(syncUrl, 196)
       .then((svg) => {
         if (!cancelled) setQrMarkup(svg)
       })

--- a/src/features/groups/SyncPanel.tsx
+++ b/src/features/groups/SyncPanel.tsx
@@ -308,7 +308,7 @@ function HandoffCard({
   onCancel: () => void
 }) {
   return (
-    <div className={`${embedded ? 'bg-primary/5' : 'bg-muted/15'} px-2 py-1.5 sm:px-3`}>
+    <div className={`${embedded ? 'rounded-[28px] bg-slate-50 dark:bg-slate-900/40' : 'bg-muted/15'} px-3 py-2 sm:px-4`}>
       <div className="mx-auto flex max-w-[272px] flex-col items-center text-center">
         <div className="mb-2.5 flex items-center gap-2 self-start text-sm font-semibold text-foreground">
           <div className="rounded-full bg-success/10 p-1.5 text-success">
@@ -477,7 +477,7 @@ export function SyncPanel({ groupId, embedded = false, onActiveStateChange }: Sy
   }
 
   const content = (
-    <div className="space-y-4 rounded-[28px] bg-slate-50 p-3 dark:bg-slate-900/40">
+    <div className="space-y-4">
       {showSetupCopy && !hideSetupWhileWaiting && (
         <div className="space-y-5 px-1">
           <div className="flex items-start gap-3">

--- a/src/features/groups/SyncPanel.tsx
+++ b/src/features/groups/SyncPanel.tsx
@@ -308,19 +308,19 @@ function HandoffCard({
   onCancel: () => void
 }) {
   return (
-    <div className={`${embedded ? 'bg-primary/5' : 'bg-muted/15'} px-2 py-2 sm:px-3`}>
-      <div className="mx-auto flex max-w-[280px] flex-col items-center text-center">
-        <div className="mb-3 flex items-center gap-2 self-start text-sm font-semibold text-foreground">
+    <div className={`${embedded ? 'bg-primary/5' : 'bg-muted/15'} px-2 py-1.5 sm:px-3`}>
+      <div className="mx-auto flex max-w-[272px] flex-col items-center text-center">
+        <div className="mb-2.5 flex items-center gap-2 self-start text-sm font-semibold text-foreground">
           <div className="rounded-full bg-success/10 p-1.5 text-success">
             <CheckCircle2 className="h-4 w-4" />
           </div>
           <span>Sincronització activa</span>
         </div>
 
-        <div className="w-full rounded-[28px] bg-white p-3 shadow-[0_10px_30px_rgba(15,23,42,0.08)]">
+        <div className="w-full rounded-[32px] bg-white p-2.5 shadow-[0_10px_26px_rgba(15,23,42,0.08)]">
           {qrMarkup ? (
             <div
-              className="qr-frame aspect-square w-full overflow-hidden rounded-[24px] bg-white"
+              className="qr-frame aspect-square w-full overflow-hidden rounded-[28px] bg-white"
               dangerouslySetInnerHTML={{ __html: qrMarkup }}
             />
           ) : (
@@ -330,36 +330,36 @@ function HandoffCard({
           )}
         </div>
 
-        <div className="mt-4 space-y-1">
-          <p className="text-lg font-semibold text-foreground">Escaneja el QR</p>
+        <div className="mt-3 space-y-1">
+          <p className="text-[1.7rem] font-semibold leading-none text-foreground">Escaneja el QR</p>
           <p className="text-sm leading-5 text-muted-foreground">Obre aquest grup a l’altre dispositiu amb el QR o amb l’enllaç temporal.</p>
         </div>
 
-        <div className="mt-4 w-full space-y-2">
-          <Button onClick={onShare} className="h-11 w-full rounded-2xl shadow-sm">
+        <div className="mt-3 w-full space-y-2">
+          <Button onClick={onShare} className="h-10.5 w-full rounded-full shadow-sm">
             {sharedLinkStatus !== 'idle' ? <Check className="mr-2 h-4 w-4" /> : <Share2 className="mr-2 h-4 w-4" />}
             {sharedLinkStatus === 'shared' ? 'Enllaç compartit' : sharedLinkStatus === 'copied' ? 'Enllaç copiat' : 'Compartir enllaç'}
           </Button>
 
-          <Button type="button" variant="outline" onClick={onCopy} className="h-11 w-full rounded-2xl bg-background/90">
+          <Button type="button" variant="outline" onClick={onCopy} className="h-10.5 w-full rounded-full bg-background/90">
             {linkCopied ? <Check className="mr-2 h-4 w-4" /> : <Copy className="mr-2 h-4 w-4" />}
             {linkCopied ? 'Enllaç copiat' : 'Copiar enllaç'}
           </Button>
         </div>
 
-        <div className="mt-3 w-full text-left">
+        <div className="mt-2.5 w-full text-left">
           <div className="flex items-start gap-2 text-xs text-muted-foreground">
             <Link2 className="mt-0.5 h-3.5 w-3.5 shrink-0" />
             <span className="truncate">{syncUrl.replace(/^https?:\/\//, '')}</span>
           </div>
         </div>
 
-        <div className="mt-4 flex w-full items-start gap-2 text-left text-xs text-muted-foreground">
+        <div className="mt-3 flex w-full items-start gap-2 text-left text-xs text-muted-foreground">
           <ShieldCheck className="mt-0.5 h-3.5 w-3.5 shrink-0 text-success" />
           <p className="leading-5">Privat per disseny. Enllaç temporal i dades xifrades amb la contrasenya del grup.</p>
         </div>
 
-        <Button type="button" variant="ghost" onClick={onCancel} className="mt-3 h-9 px-0 text-xs text-muted-foreground hover:bg-transparent">
+        <Button type="button" variant="ghost" onClick={onCancel} className="mt-2 h-8 px-0 text-xs text-muted-foreground hover:bg-transparent">
           Desactivar sincronització
         </Button>
       </div>
@@ -410,7 +410,7 @@ export function SyncPanel({ groupId, embedded = false, onActiveStateChange }: Sy
       return
     }
 
-    createQrSvg(syncUrl, 196)
+    createQrSvg(syncUrl, 184)
       .then((svg) => {
         if (!cancelled) setQrMarkup(svg)
       })

--- a/src/features/groups/SyncPanel.tsx
+++ b/src/features/groups/SyncPanel.tsx
@@ -308,20 +308,22 @@ function HandoffCard({
   onCancel: () => void
 }) {
   return (
-    <div className={`rounded-[24px] border ${embedded ? 'border-primary/20 bg-primary/5' : 'bg-muted/20'} p-3`}>
+    <div className={`rounded-[24px] border ${embedded ? 'border-primary/20 bg-primary/5' : 'bg-muted/20'} p-3 sm:p-4`}>
       <div className="space-y-3">
-        <div className="flex items-start gap-3 rounded-2xl border bg-background/90 p-3">
-          <div className="rounded-full bg-success/10 p-2 text-success">
-            <CheckCircle2 className="h-4 w-4" />
-          </div>
-          <div className="space-y-1">
-            <p className="text-sm font-semibold text-foreground">Sincronització activa</p>
-            <p className="text-xs leading-5 text-muted-foreground">Escaneja el QR o obre l’enllaç en l’altre dispositiu.</p>
+        <div className="rounded-2xl border bg-background/95 px-4 py-3">
+          <div className="flex items-start gap-3">
+            <div className="rounded-full bg-success/10 p-2 text-success">
+              <CheckCircle2 className="h-4 w-4" />
+            </div>
+            <div className="min-w-0 space-y-1">
+              <p className="text-sm font-semibold text-foreground">Sincronització activa</p>
+              <p className="text-xs leading-5 text-muted-foreground">Escaneja aquest QR a l’altre dispositiu o obre-hi l’enllaç temporal.</p>
+            </div>
           </div>
         </div>
 
-        <div className="grid gap-3 sm:grid-cols-[minmax(0,188px)_minmax(0,1fr)] sm:items-start">
-          <div className="mx-auto w-full max-w-[188px] rounded-[24px] border bg-white p-2 shadow-sm">
+        <div className="flex flex-col items-center gap-3 text-center">
+          <div className="w-full max-w-[220px] rounded-[24px] border bg-white p-2 shadow-sm">
             {qrMarkup ? (
               <div
                 className="qr-frame aspect-square w-full overflow-hidden rounded-[18px] bg-white"
@@ -334,45 +336,43 @@ function HandoffCard({
             )}
           </div>
 
-          <div className="space-y-3">
-            <div className="space-y-1">
-              <p className="text-sm font-semibold text-foreground">Escaneja el QR</p>
-              <p className="text-xs leading-5 text-muted-foreground">Si no et va bé, comparteix o copia l’enllaç temporal.</p>
-            </div>
-
-            <div className="rounded-2xl border bg-background px-3 py-2.5">
-              <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                <Link2 className="h-3.5 w-3.5 shrink-0" />
-                <span className="truncate">{syncUrl.replace(/^https?:\/\//, '')}</span>
-              </div>
-            </div>
-
-            <div className="grid gap-2 sm:grid-cols-2">
-              <Button onClick={onShare} className="w-full">
-                {sharedLinkStatus !== 'idle' ? <Check className="mr-2 h-4 w-4" /> : <Share2 className="mr-2 h-4 w-4" />}
-                {sharedLinkStatus === 'shared' ? 'Compartit' : sharedLinkStatus === 'copied' ? 'Copiat' : 'Compartir'}
-              </Button>
-
-              <Button type="button" variant="outline" onClick={onCopy} className="w-full">
-                {linkCopied ? <Check className="mr-2 h-4 w-4" /> : <Copy className="mr-2 h-4 w-4" />}
-                {linkCopied ? 'Copiat' : 'Copiar'}
-              </Button>
-            </div>
-
-            <div className="rounded-2xl border border-emerald-200 bg-emerald-50 px-3 py-2.5 text-xs text-emerald-950 dark:border-emerald-900/40 dark:bg-emerald-950/30 dark:text-emerald-100">
-              <div className="flex items-center gap-2 font-medium">
-                <ShieldCheck className="h-3.5 w-3.5" />
-                <span>Privat per disseny</span>
-              </div>
-              <p className="mt-1 leading-5 text-emerald-900/80 dark:text-emerald-100/80">
-                Enllaç temporal. Dades xifrades amb la contrasenya del grup.
-              </p>
-            </div>
-
-            <Button type="button" variant="ghost" onClick={onCancel} className="h-9 justify-start px-0 text-xs text-muted-foreground hover:bg-transparent">
-              Desactivar sincronització
-            </Button>
+          <div className="space-y-1">
+            <p className="text-base font-semibold text-foreground">Escaneja el QR</p>
+            <p className="text-sm text-muted-foreground">Si no et va bé, comparteix o copia l’enllaç temporal.</p>
           </div>
+        </div>
+
+        <div className="space-y-2">
+          <div className="rounded-2xl border bg-background px-3 py-2.5">
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <Link2 className="h-3.5 w-3.5 shrink-0" />
+              <span className="truncate">{syncUrl.replace(/^https?:\/\//, '')}</span>
+            </div>
+          </div>
+
+          <Button onClick={onShare} className="w-full">
+            {sharedLinkStatus !== 'idle' ? <Check className="mr-2 h-4 w-4" /> : <Share2 className="mr-2 h-4 w-4" />}
+            {sharedLinkStatus === 'shared' ? 'Enllaç compartit' : sharedLinkStatus === 'copied' ? 'Enllaç copiat' : 'Compartir enllaç'}
+          </Button>
+
+          <Button type="button" variant="outline" onClick={onCopy} className="w-full">
+            {linkCopied ? <Check className="mr-2 h-4 w-4" /> : <Copy className="mr-2 h-4 w-4" />}
+            {linkCopied ? 'Enllaç copiat' : 'Copiar enllaç'}
+          </Button>
+
+          <div className="rounded-2xl border border-emerald-200 bg-emerald-50 px-3 py-2.5 text-left text-xs text-emerald-950 dark:border-emerald-900/40 dark:bg-emerald-950/30 dark:text-emerald-100">
+            <div className="flex items-center gap-2 font-medium">
+              <ShieldCheck className="h-3.5 w-3.5" />
+              <span>Privat per disseny</span>
+            </div>
+            <p className="mt-1 leading-5 text-emerald-900/80 dark:text-emerald-100/80">
+              Enllaç temporal. Dades xifrades amb la contrasenya del grup.
+            </p>
+          </div>
+
+          <Button type="button" variant="ghost" onClick={onCancel} className="h-9 w-full text-xs text-muted-foreground hover:bg-transparent">
+            Desactivar sincronització
+          </Button>
         </div>
       </div>
     </div>

--- a/src/features/groups/SyncPanel.tsx
+++ b/src/features/groups/SyncPanel.tsx
@@ -477,7 +477,7 @@ export function SyncPanel({ groupId, embedded = false, onActiveStateChange }: Sy
   }
 
   const content = (
-    <div className="space-y-4">
+    <div className="space-y-4 rounded-[28px] bg-slate-50 p-3 dark:bg-slate-900/40">
       {showSetupCopy && !hideSetupWhileWaiting && (
         <div className="space-y-5 px-1">
           <div className="flex items-start gap-3">

--- a/src/features/groups/SyncPanel.tsx
+++ b/src/features/groups/SyncPanel.tsx
@@ -308,22 +308,20 @@ function HandoffCard({
   onCancel: () => void
 }) {
   return (
-    <div className={`rounded-[24px] border ${embedded ? 'border-primary/20 bg-primary/5' : 'bg-muted/20'} p-3 sm:p-4`}>
-      <div className="space-y-3">
-        <div className="rounded-2xl border bg-background/95 px-4 py-3">
-          <div className="flex items-start gap-3">
-            <div className="rounded-full bg-success/10 p-2 text-success">
-              <CheckCircle2 className="h-4 w-4" />
-            </div>
-            <div className="min-w-0 space-y-1">
-              <p className="text-sm font-semibold text-foreground">Sincronització activa</p>
-              <p className="text-xs leading-5 text-muted-foreground">Escaneja aquest QR a l’altre dispositiu o obre-hi l’enllaç temporal.</p>
-            </div>
+    <div className={`rounded-[28px] ${embedded ? 'bg-primary/5' : 'bg-muted/20'} px-4 py-4 sm:px-5`}>
+      <div className="space-y-4">
+        <div className="flex items-start gap-3">
+          <div className="mt-0.5 rounded-full bg-success/10 p-2 text-success">
+            <CheckCircle2 className="h-4 w-4" />
+          </div>
+          <div className="min-w-0 space-y-1">
+            <p className="text-sm font-semibold text-foreground">Sincronització activa</p>
+            <p className="text-sm leading-5 text-muted-foreground">Escaneja aquest QR a l’altre dispositiu o obre-hi l’enllaç temporal.</p>
           </div>
         </div>
 
-        <div className="flex flex-col items-center gap-3 text-center">
-          <div className="w-full max-w-[220px] rounded-[24px] border bg-white p-2 shadow-sm">
+        <div className="flex flex-col items-center text-center">
+          <div className="w-full max-w-[208px] bg-white p-2 shadow-sm ring-1 ring-black/10 rounded-[24px]">
             {qrMarkup ? (
               <div
                 className="qr-frame aspect-square w-full overflow-hidden rounded-[18px] bg-white"
@@ -336,31 +334,31 @@ function HandoffCard({
             )}
           </div>
 
-          <div className="space-y-1">
+          <div className="mt-3 space-y-1">
             <p className="text-base font-semibold text-foreground">Escaneja el QR</p>
-            <p className="text-sm text-muted-foreground">Si no et va bé, comparteix o copia l’enllaç temporal.</p>
+            <p className="text-sm leading-5 text-muted-foreground">Si no et va bé, comparteix o copia l’enllaç temporal.</p>
           </div>
         </div>
 
-        <div className="space-y-2">
-          <div className="rounded-2xl border bg-background px-3 py-2.5">
+        <div className="space-y-2.5">
+          <div className="bg-background/80 px-3 py-2.5 rounded-2xl">
             <div className="flex items-center gap-2 text-xs text-muted-foreground">
               <Link2 className="h-3.5 w-3.5 shrink-0" />
               <span className="truncate">{syncUrl.replace(/^https?:\/\//, '')}</span>
             </div>
           </div>
 
-          <Button onClick={onShare} className="w-full">
+          <Button onClick={onShare} className="w-full shadow-sm">
             {sharedLinkStatus !== 'idle' ? <Check className="mr-2 h-4 w-4" /> : <Share2 className="mr-2 h-4 w-4" />}
             {sharedLinkStatus === 'shared' ? 'Enllaç compartit' : sharedLinkStatus === 'copied' ? 'Enllaç copiat' : 'Compartir enllaç'}
           </Button>
 
-          <Button type="button" variant="outline" onClick={onCopy} className="w-full">
+          <Button type="button" variant="outline" onClick={onCopy} className="w-full bg-background/90">
             {linkCopied ? <Check className="mr-2 h-4 w-4" /> : <Copy className="mr-2 h-4 w-4" />}
             {linkCopied ? 'Enllaç copiat' : 'Copiar enllaç'}
           </Button>
 
-          <div className="rounded-2xl border border-emerald-200 bg-emerald-50 px-3 py-2.5 text-left text-xs text-emerald-950 dark:border-emerald-900/40 dark:bg-emerald-950/30 dark:text-emerald-100">
+          <div className="bg-emerald-50/80 px-3 py-2.5 rounded-2xl text-left text-xs text-emerald-950 dark:bg-emerald-950/30 dark:text-emerald-100">
             <div className="flex items-center gap-2 font-medium">
               <ShieldCheck className="h-3.5 w-3.5" />
               <span>Privat per disseny</span>

--- a/src/features/groups/SyncPanel.tsx
+++ b/src/features/groups/SyncPanel.tsx
@@ -607,9 +607,10 @@ export function SyncPanel({ groupId, embedded = false, onActiveStateChange }: Sy
                 </div>
               )}
               {isWaitingForPeer && !isEmbeddedWaiting && (
-                <p className="text-center text-sm text-muted-foreground">
-                  Esperant que l’altre dispositiu entri…
-                </p>
+                <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
+                  <Loader2 className="h-4 w-4 animate-spin text-primary" />
+                  <p>Esperant que l’altre dispositiu entri…</p>
+                </div>
               )}
               {showCompactStatusDetails && !isWaitingForPeer && (sync.remotePeerIds.length > 0 || sync.lastAttemptAt || sync.lastSuccessAt) && (
                 <details className="rounded-md bg-muted/50 px-3 py-2 text-xs text-muted-foreground">
@@ -633,20 +634,26 @@ export function SyncPanel({ groupId, embedded = false, onActiveStateChange }: Sy
 
             {/* Instructions for host + share link */}
             {mode === 'host' && sync.state === 'waiting-for-peer' && (
-              <HandoffCard
-                qrMarkup={qrMarkup}
-                embedded={embedded}
-                sharedLinkStatus={sharedLinkStatus}
-                linkCopied={linkCopied}
-                syncUrl={syncUrl}
-                onShare={() => {
-                  void handleCopySyncLink()
-                }}
-                onCopy={() => {
-                  void handleCopyRawLink()
-                }}
-                onCancel={handleReset}
-              />
+              <div className="space-y-3">
+                <div className="flex items-center justify-center gap-2 text-sm text-primary">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  <span className="font-medium">Esperant connexió de l’altre dispositiu…</span>
+                </div>
+                <HandoffCard
+                  qrMarkup={qrMarkup}
+                  embedded={embedded}
+                  sharedLinkStatus={sharedLinkStatus}
+                  linkCopied={linkCopied}
+                  syncUrl={syncUrl}
+                  onShare={() => {
+                    void handleCopySyncLink()
+                  }}
+                  onCopy={() => {
+                    void handleCopyRawLink()
+                  }}
+                  onCancel={handleReset}
+                />
+              </div>
             )}
 
             {/* Sync report */}


### PR DESCRIPTION
## Què canvia
- redissenya el modal de compartir/sincronitzar grup seguint el mockup validat de 3 passos
- reforça l’estat inicial amb millor jerarquia, copy més clar i CTA d’activació més directa
- dona protagonisme al QR, a l’enllaç compartible i al missatge de privacitat en l’estat actiu

## Validació
- npm run build

## Issue relacionada
- closes #160
