### PR TITLE
feat: duplicate expense from existing entry

### DIFF
--- a/src/features/expenses/ExpenseList.tsx
+++ b/src/features/expenses/ExpenseList.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useMemo } from 'react'
-import { Plus, Trash2, Camera, ImagePlus, X, Archive, ArchiveRestore, Pencil, Sparkles, Users, ArrowRight, Paperclip } from 'lucide-react'
+import { Plus, Trash2, Camera, ImagePlus, X, Archive, ArchiveRestore, Pencil, Sparkles, Users, ArrowRight, Paperclip, Copy } from 'lucide-react'
 import type { Group, Expense, ActivityEntry } from '../../domain/entities'
 import { computeExpenseShares, calculateBalances, isExpenseArchivable } from '../../domain/services/balances'
 import { useStore } from '../../store'
@@ -143,6 +143,7 @@ export function ExpenseList({ group }: ExpenseListProps) {
   const [proportions, setProportions] = useState<Record<string, string>>({})
   const [fixedAmounts, setFixedAmounts] = useState<Record<string, string>>({})
   const [showForm, setShowForm] = useState(false)
+  const [expenseDate, setExpenseDate] = useState(() => new Date().toISOString().split('T')[0])
   const [receiptImage, setReceiptImage] = useState<string | null>(null)
   const [viewingReceipt, setViewingReceipt] = useState<ViewingReceiptState | null>(null)
   const [receiptError, setReceiptError] = useState<string | null>(null)
@@ -198,6 +199,7 @@ export function ExpenseList({ group }: ExpenseListProps) {
     setSplitType('equal')
     setProportions({})
     setFixedAmounts({})
+    setExpenseDate(new Date().toISOString().split('T')[0])
     setReceiptImage(null)
     setReceiptError(null)
     setShowForm(false)
@@ -225,8 +227,8 @@ export function ExpenseList({ group }: ExpenseListProps) {
     setSplitAmong(activeMembers.map((m) => m.id))
   }
 
-  const startEdit = (expense: Expense) => {
-    setEditingExpenseId(expense.id)
+  const fillExpenseForm = (expense: Expense, options?: { duplicate?: boolean }) => {
+    setEditingExpenseId(options?.duplicate ? null : expense.id)
     setDescription(expense.description)
     setAmount(expense.amount.toString())
     setPayerId(expense.payerId)
@@ -242,9 +244,18 @@ export function ExpenseList({ group }: ExpenseListProps) {
         expense.splitAmong.map((id) => [id, String(expense.splitFixedAmounts?.[id] ?? '')]),
       ),
     )
-    setReceiptImage(expense.receiptImage ?? null)
+    setExpenseDate(options?.duplicate ? new Date().toISOString().split('T')[0] : expense.date)
+    setReceiptImage(options?.duplicate ? null : expense.receiptImage ?? null)
     setReceiptError(null)
     setShowForm(true)
+  }
+
+  const startEdit = (expense: Expense) => {
+    fillExpenseForm(expense)
+  }
+
+  const startDuplicate = (expense: Expense) => {
+    fillExpenseForm(expense, { duplicate: true })
   }
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -261,7 +272,7 @@ export function ExpenseList({ group }: ExpenseListProps) {
       payerId,
       splitAmong,
       ...splitFields,
-      date: new Date().toISOString().split('T')[0],
+      date: expenseDate,
       receiptImage: receiptImage ?? undefined,
     }
 
@@ -280,7 +291,6 @@ export function ExpenseList({ group }: ExpenseListProps) {
       await updateExpense({
         ...existing,
         ...baseExpense,
-        date: existing.date,
         computedShares,
       })
     } else {
@@ -515,20 +525,28 @@ export function ExpenseList({ group }: ExpenseListProps) {
                       required
                     />
                   </div>
-                  <div className="flex gap-2">
+                  <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_180px]">
+                    <div className="flex gap-2">
+                      <Input
+                        type="number"
+                        value={amount}
+                        onChange={(e) => setAmount(e.target.value)}
+                        placeholder="Import"
+                        step="0.01"
+                        min="0.01"
+                        className="flex-1"
+                        required
+                      />
+                      <span className="flex items-center text-muted-foreground">
+                        {symbol}
+                      </span>
+                    </div>
                     <Input
-                      type="number"
-                      value={amount}
-                      onChange={(e) => setAmount(e.target.value)}
-                      placeholder="Import"
-                      step="0.01"
-                      min="0.01"
-                      className="flex-1"
+                      type="date"
+                      value={expenseDate}
+                      onChange={(e) => setExpenseDate(e.target.value)}
                       required
                     />
-                    <span className="flex items-center text-muted-foreground">
-                      {symbol}
-                    </span>
                   </div>
                   <div className="space-y-1">
                     <Label>Qui ha pagat?</Label>
@@ -907,15 +925,26 @@ export function ExpenseList({ group }: ExpenseListProps) {
                               </Button>
                             )}
                             {!showArchived && !group.archived && (
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                onClick={() => startEdit(expense)}
-                                className="h-auto px-1 py-0 text-xs text-muted-foreground hover:text-foreground"
-                              >
-                                <Pencil className="mr-1 h-3 w-3" />
-                                Editar
-                              </Button>
+                              <>
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() => startDuplicate(expense)}
+                                  className="h-auto px-1 py-0 text-xs text-muted-foreground hover:text-foreground"
+                                >
+                                  <Copy className="mr-1 h-3 w-3" />
+                                  Duplicar
+                                </Button>
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() => startEdit(expense)}
+                                  className="h-auto px-1 py-0 text-xs text-muted-foreground hover:text-foreground"
+                                >
+                                  <Pencil className="mr-1 h-3 w-3" />
+                                  Editar
+                                </Button>
+                              </>
                             )}
                             {showArchived ? (
                               !group.archived && (

--- a/src/features/expenses/ExpenseList.tsx
+++ b/src/features/expenses/ExpenseList.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useMemo } from 'react'
-import { Plus, Trash2, Camera, ImagePlus, X, Archive, ArchiveRestore, Pencil, Sparkles, Users, ArrowRight, Paperclip, Copy } from 'lucide-react'
+import { Plus, Trash2, Camera, ImagePlus, X, Archive, ArchiveRestore, Pencil, Sparkles, Users, ArrowRight, Paperclip, MoreHorizontal, Copy } from 'lucide-react'
 import type { Group, Expense, ActivityEntry } from '../../domain/entities'
 import { computeExpenseShares, calculateBalances, isExpenseArchivable } from '../../domain/services/balances'
 import { useStore } from '../../store'
@@ -149,6 +149,7 @@ export function ExpenseList({ group }: ExpenseListProps) {
   const [receiptError, setReceiptError] = useState<string | null>(null)
   const [showArchived, setShowArchived] = useState(false)
   const [activityEntries, setActivityEntries] = useState<ActivityEntry[]>([])
+  const [openExpenseMenuId, setOpenExpenseMenuId] = useState<string | null>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const cameraInputRef = useRef<HTMLInputElement>(null)
   const modalRef = useRef<HTMLDivElement>(null)
@@ -188,6 +189,35 @@ export function ExpenseList({ group }: ExpenseListProps) {
   const archivedExpenses = expenses.filter((e) => e.archived)
   const visibleExpenses = showArchived ? archivedExpenses : activeExpenses
   const archivableCount = activeExpenses.filter((e) => isExpenseArchivable(e, balances)).length
+
+  useEffect(() => {
+    const handleDocumentClick = () => setOpenExpenseMenuId(null)
+    document.addEventListener('click', handleDocumentClick)
+    return () => document.removeEventListener('click', handleDocumentClick)
+  }, [])
+
+  const startDuplicate = (expense: Expense) => {
+    setEditingExpenseId(null)
+    setDescription(expense.description)
+    setAmount(expense.amount.toString())
+    setPayerId(expense.payerId)
+    setSplitAmong(expense.splitAmong)
+    setSplitType(expense.splitType ?? 'equal')
+    setProportions(
+      Object.fromEntries(
+        expense.splitAmong.map((id) => [id, String(expense.splitProportions?.[id] ?? 1)]),
+      ),
+    )
+    setFixedAmounts(
+      Object.fromEntries(
+        expense.splitAmong.map((id) => [id, String(expense.splitFixedAmounts?.[id] ?? '')]),
+      ),
+    )
+    setReceiptImage(expense.receiptImage ?? null)
+    setReceiptError(null)
+    setShowForm(true)
+    setOpenExpenseMenuId(null)
+  }
 
   const resetForm = () => {
     receiptLoadRequestRef.current += 1
@@ -924,28 +954,6 @@ export function ExpenseList({ group }: ExpenseListProps) {
                                 Adjunt
                               </Button>
                             )}
-                            {!showArchived && !group.archived && (
-                              <>
-                                <Button
-                                  variant="ghost"
-                                  size="sm"
-                                  onClick={() => startDuplicate(expense)}
-                                  className="h-auto px-1 py-0 text-xs text-muted-foreground hover:text-foreground"
-                                >
-                                  <Copy className="mr-1 h-3 w-3" />
-                                  Duplicar
-                                </Button>
-                                <Button
-                                  variant="ghost"
-                                  size="sm"
-                                  onClick={() => startEdit(expense)}
-                                  className="h-auto px-1 py-0 text-xs text-muted-foreground hover:text-foreground"
-                                >
-                                  <Pencil className="mr-1 h-3 w-3" />
-                                  Editar
-                                </Button>
-                              </>
-                            )}
                             {showArchived ? (
                               !group.archived && (
                                 <Button
@@ -959,37 +967,73 @@ export function ExpenseList({ group }: ExpenseListProps) {
                                 </Button>
                               )
                             ) : (
-                              <AlertDialog>
-                                {!group.archived && (
-                                  <AlertDialogTrigger asChild>
-                                    <Button
-                                      variant="ghost"
-                                      size="sm"
-                                      className="h-auto px-1 py-0 text-xs text-muted-foreground hover:text-destructive"
+                              !group.archived && (
+                                <div className="relative">
+                                  <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    onClick={(e) => {
+                                      e.stopPropagation()
+                                      setOpenExpenseMenuId((current) => current === expense.id ? null : expense.id)
+                                    }}
+                                    className="h-7 w-7 p-0 text-muted-foreground hover:text-foreground"
+                                    aria-label="Més accions"
+                                  >
+                                    <MoreHorizontal className="h-4 w-4" />
+                                  </Button>
+                                  {openExpenseMenuId === expense.id && (
+                                    <div
+                                      className="absolute right-0 top-8 z-20 min-w-[10rem] rounded-xl border bg-popover p-1 shadow-lg"
+                                      onClick={(e) => e.stopPropagation()}
                                     >
-                                      <Trash2 className="mr-1 h-3 w-3" />
-                                      Eliminar
-                                    </Button>
-                                  </AlertDialogTrigger>
-                                )}
-                                <AlertDialogContent>
-                                  <AlertDialogHeader>
-                                    <AlertDialogTitle>Eliminar despesa</AlertDialogTitle>
-                                    <AlertDialogDescription>
-                                      Estàs segur que vols eliminar la despesa &quot;{expense.description}&quot;? Aquesta acció no es pot desfer.
-                                    </AlertDialogDescription>
-                                  </AlertDialogHeader>
-                                  <AlertDialogFooter>
-                                    <AlertDialogCancel>Cancel·lar</AlertDialogCancel>
-                                    <AlertDialogAction
-                                      onClick={() => deleteExpense(expense.id)}
-                                      className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                                    >
-                                      Eliminar
-                                    </AlertDialogAction>
-                                  </AlertDialogFooter>
-                                </AlertDialogContent>
-                              </AlertDialog>
+                                      <button
+                                        type="button"
+                                        onClick={() => startEdit(expense)}
+                                        className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-foreground hover:bg-muted"
+                                      >
+                                        <Pencil className="h-4 w-4" />
+                                        Editar
+                                      </button>
+                                      <button
+                                        type="button"
+                                        onClick={() => startDuplicate(expense)}
+                                        className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-foreground hover:bg-muted"
+                                      >
+                                        <Copy className="h-4 w-4" />
+                                        Duplicar
+                                      </button>
+                                      <AlertDialog>
+                                        <AlertDialogTrigger asChild>
+                                          <button
+                                            type="button"
+                                            className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-destructive hover:bg-muted"
+                                          >
+                                            <Trash2 className="h-4 w-4" />
+                                            Eliminar
+                                          </button>
+                                        </AlertDialogTrigger>
+                                        <AlertDialogContent>
+                                          <AlertDialogHeader>
+                                            <AlertDialogTitle>Eliminar despesa</AlertDialogTitle>
+                                            <AlertDialogDescription>
+                                              Estàs segur que vols eliminar la despesa &quot;{expense.description}&quot;? Aquesta acció no es pot desfer.
+                                            </AlertDialogDescription>
+                                          </AlertDialogHeader>
+                                          <AlertDialogFooter>
+                                            <AlertDialogCancel>Cancel·lar</AlertDialogCancel>
+                                            <AlertDialogAction
+                                              onClick={() => deleteExpense(expense.id)}
+                                              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                                            >
+                                              Eliminar
+                                            </AlertDialogAction>
+                                          </AlertDialogFooter>
+                                        </AlertDialogContent>
+                                      </AlertDialog>
+                                    </div>
+                                  )}
+                                </div>
+                              )
                             )}
                           </div>
                         </div>

--- a/src/features/expenses/ExpenseList.tsx
+++ b/src/features/expenses/ExpenseList.tsx
@@ -196,29 +196,6 @@ export function ExpenseList({ group }: ExpenseListProps) {
     return () => document.removeEventListener('click', handleDocumentClick)
   }, [])
 
-  const startDuplicate = (expense: Expense) => {
-    setEditingExpenseId(null)
-    setDescription(expense.description)
-    setAmount(expense.amount.toString())
-    setPayerId(expense.payerId)
-    setSplitAmong(expense.splitAmong)
-    setSplitType(expense.splitType ?? 'equal')
-    setProportions(
-      Object.fromEntries(
-        expense.splitAmong.map((id) => [id, String(expense.splitProportions?.[id] ?? 1)]),
-      ),
-    )
-    setFixedAmounts(
-      Object.fromEntries(
-        expense.splitAmong.map((id) => [id, String(expense.splitFixedAmounts?.[id] ?? '')]),
-      ),
-    )
-    setReceiptImage(expense.receiptImage ?? null)
-    setReceiptError(null)
-    setShowForm(true)
-    setOpenExpenseMenuId(null)
-  }
-
   const resetForm = () => {
     receiptLoadRequestRef.current += 1
     setEditingExpenseId(null)
@@ -278,6 +255,7 @@ export function ExpenseList({ group }: ExpenseListProps) {
     setReceiptImage(options?.duplicate ? null : expense.receiptImage ?? null)
     setReceiptError(null)
     setShowForm(true)
+    setOpenExpenseMenuId(null)
   }
 
   const startEdit = (expense: Expense) => {

--- a/src/features/expenses/ExpenseList.tsx
+++ b/src/features/expenses/ExpenseList.tsx
@@ -41,6 +41,14 @@ const MAX_RECEIPT_DIMENSION = 1600
 const MAX_RECEIPT_SOURCE_PIXELS = 24_000_000
 const RECEIPT_OUTPUT_QUALITY = 0.78
 
+function getTodayLocalDate(): string {
+  const now = new Date()
+  const year = now.getFullYear()
+  const month = String(now.getMonth() + 1).padStart(2, '0')
+  const day = String(now.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
 async function readBlobAsDataUrl(blob: Blob): Promise<string> {
   return await new Promise<string>((resolve, reject) => {
     const reader = new FileReader()
@@ -143,7 +151,7 @@ export function ExpenseList({ group }: ExpenseListProps) {
   const [proportions, setProportions] = useState<Record<string, string>>({})
   const [fixedAmounts, setFixedAmounts] = useState<Record<string, string>>({})
   const [showForm, setShowForm] = useState(false)
-  const [expenseDate, setExpenseDate] = useState(() => new Date().toISOString().split('T')[0])
+  const [expenseDate, setExpenseDate] = useState(() => getTodayLocalDate())
   const [receiptImage, setReceiptImage] = useState<string | null>(null)
   const [viewingReceipt, setViewingReceipt] = useState<ViewingReceiptState | null>(null)
   const [receiptError, setReceiptError] = useState<string | null>(null)
@@ -206,7 +214,7 @@ export function ExpenseList({ group }: ExpenseListProps) {
     setSplitType('equal')
     setProportions({})
     setFixedAmounts({})
-    setExpenseDate(new Date().toISOString().split('T')[0])
+    setExpenseDate(getTodayLocalDate())
     setReceiptImage(null)
     setReceiptError(null)
     setShowForm(false)
@@ -251,7 +259,7 @@ export function ExpenseList({ group }: ExpenseListProps) {
         expense.splitAmong.map((id) => [id, String(expense.splitFixedAmounts?.[id] ?? '')]),
       ),
     )
-    setExpenseDate(options?.duplicate ? new Date().toISOString().split('T')[0] : expense.date)
+    setExpenseDate(options?.duplicate ? getTodayLocalDate() : expense.date)
     setReceiptImage(options?.duplicate ? null : expense.receiptImage ?? null)
     setReceiptError(null)
     setShowForm(true)
@@ -549,12 +557,17 @@ export function ExpenseList({ group }: ExpenseListProps) {
                         {symbol}
                       </span>
                     </div>
-                    <Input
-                      type="date"
-                      value={expenseDate}
-                      onChange={(e) => setExpenseDate(e.target.value)}
-                      required
-                    />
+                    <div className="space-y-1">
+                      <Label htmlFor="expense-date">Data</Label>
+                      <Input
+                        id="expense-date"
+                        type="date"
+                        aria-label="Data de la despesa"
+                        value={expenseDate}
+                        onChange={(e) => setExpenseDate(e.target.value)}
+                        required
+                      />
+                    </div>
                   </div>
                   <div className="space-y-1">
                     <Label>Qui ha pagat?</Label>
@@ -956,16 +969,29 @@ export function ExpenseList({ group }: ExpenseListProps) {
                                     }}
                                     className="h-7 w-7 p-0 text-muted-foreground hover:text-foreground"
                                     aria-label="Més accions"
+                                    aria-haspopup="menu"
+                                    aria-expanded={openExpenseMenuId === expense.id}
+                                    aria-controls={`expense-actions-${expense.id}`}
                                   >
                                     <MoreHorizontal className="h-4 w-4" />
                                   </Button>
                                   {openExpenseMenuId === expense.id && (
                                     <div
+                                      id={`expense-actions-${expense.id}`}
+                                      role="menu"
+                                      aria-label={`Accions per a ${expense.description}`}
                                       className="absolute right-0 top-8 z-20 min-w-[10rem] rounded-xl border bg-popover p-1 shadow-lg"
                                       onClick={(e) => e.stopPropagation()}
+                                      onKeyDown={(e) => {
+                                        if (e.key === 'Escape') {
+                                          e.stopPropagation()
+                                          setOpenExpenseMenuId(null)
+                                        }
+                                      }}
                                     >
                                       <button
                                         type="button"
+                                        role="menuitem"
                                         onClick={() => startEdit(expense)}
                                         className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-foreground hover:bg-muted"
                                       >
@@ -974,6 +1000,7 @@ export function ExpenseList({ group }: ExpenseListProps) {
                                       </button>
                                       <button
                                         type="button"
+                                        role="menuitem"
                                         onClick={() => startDuplicate(expense)}
                                         className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-foreground hover:bg-muted"
                                       >
@@ -984,6 +1011,8 @@ export function ExpenseList({ group }: ExpenseListProps) {
                                         <AlertDialogTrigger asChild>
                                           <button
                                             type="button"
+                                            role="menuitem"
+                                            onClick={() => setOpenExpenseMenuId(null)}
                                             className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-destructive hover:bg-muted"
                                           >
                                             <Trash2 className="h-4 w-4" />


### PR DESCRIPTION
## Què canvia
- afegeix l'acció **Duplicar** a cada despesa activa
- obre el formulari preomplert amb concepte, import, pagador, participants i repartiment
- la còpia neix com una despesa nova i independent
- fa la **data editable** des del formulari, també útil per aquest flux

## Validació
- npm run build

## Issue relacionada
- closes #162
