### PR TITLE
feat: add local device identity substrate

### DIFF
--- a/src/features/groups/GroupList.tsx
+++ b/src/features/groups/GroupList.tsx
@@ -19,9 +19,11 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog'
+import { getLocalDeviceIdentity, needsDeviceLabelSetup } from '@/lib/device-identity'
 
 export function GroupList() {
   const { groups, groupTotals, loadGroups, addGroup, deleteGroup, importGroup } = useStore()
+  const hasPendingDeviceSetup = needsDeviceLabelSetup(getLocalDeviceIdentity())
   const [name, setName] = useState('')
   const [showForm, setShowForm] = useState(false)
   const [importStatus, setImportStatus] = useState<'idle' | 'ok' | 'error'>('idle')
@@ -178,10 +180,16 @@ export function GroupList() {
               variant="secondary"
               size="icon"
               onClick={() => navigate('/preferences')}
-              aria-label="Preferències"
-              className="shrink-0 bg-white/10 text-white hover:bg-white/20 dark:bg-white/10 dark:hover:bg-white/20"
+              aria-label={hasPendingDeviceSetup ? 'Preferències, configuració pendent' : 'Preferències'}
+              className="relative shrink-0 bg-white/10 text-white hover:bg-white/20 dark:bg-white/10 dark:hover:bg-white/20"
             >
               <Settings className="h-4 w-4" />
+              {hasPendingDeviceSetup && (
+                <span
+                  className="absolute right-2 top-2 h-2.5 w-2.5 rounded-full bg-red-400 ring-2 ring-indigo-700 dark:ring-indigo-950"
+                  aria-hidden="true"
+                />
+              )}
             </Button>
           </div>
         </div>

--- a/src/features/groups/GroupList.tsx
+++ b/src/features/groups/GroupList.tsx
@@ -186,7 +186,7 @@ export function GroupList() {
               <Settings className="h-4 w-4" />
               {hasPendingDeviceSetup && (
                 <span
-                  className="absolute right-2 top-2 h-2.5 w-2.5 rounded-full bg-red-400 ring-2 ring-indigo-700 dark:ring-indigo-950"
+                  className="absolute -right-0.5 -top-0.5 h-2.5 w-2.5 rounded-full bg-red-400 ring-2 ring-indigo-700 dark:ring-indigo-950"
                   aria-hidden="true"
                 />
               )}

--- a/src/features/groups/Preferences.tsx
+++ b/src/features/groups/Preferences.tsx
@@ -19,6 +19,7 @@ import {
 import {
   getDefaultDeviceLabel,
   getLocalDeviceIdentity,
+  needsDeviceLabelSetup,
   resetLocalDeviceLabel,
   updateLocalDeviceLabel,
 } from '@/lib/device-identity'
@@ -108,16 +109,27 @@ function DeviceIdentityCard() {
   }
 
   const defaultLabel = getDefaultDeviceLabel(identity.deviceId)
+  const needsSetup = needsDeviceLabelSetup(identity)
 
   return (
-    <Card>
+    <Card className={needsSetup ? 'border-amber-300 bg-amber-50/40 dark:border-amber-800 dark:bg-amber-950/20' : undefined}>
       <CardHeader>
         <CardTitle className="text-base flex items-center gap-2">
           <Smartphone className="h-4 w-4" />
           Aquest dispositiu
+          {needsSetup && (
+            <span className="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900/60 dark:text-amber-100">
+              Per configurar
+            </span>
+          )}
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-5">
+        {needsSetup && (
+          <div className="rounded-lg border border-amber-300 bg-amber-100/70 px-3 py-2 text-sm text-amber-950 dark:border-amber-800 dark:bg-amber-900/30 dark:text-amber-100">
+            Encara tens el nom per defecte. Canvia'l per distingir millor aquest dispositiu quan hi hagi activitat o sync.
+          </div>
+        )}
         <p className="text-sm text-muted-foreground">
           Aquesta identitat és local al dispositiu actual. L’id és estable i el nom es pot editar per fer-lo més reconeixible quan arribi a activitat o sync.
         </p>
@@ -317,11 +329,24 @@ export function Preferences() {
       <Card>
         <CardContent className="pt-6">
           <div className="flex items-start gap-3">
-            <div className="rounded-full bg-indigo-50 p-2 text-indigo-600 dark:bg-indigo-950 dark:text-indigo-300">
+            <div className="relative rounded-full bg-indigo-50 p-2 text-indigo-600 dark:bg-indigo-950 dark:text-indigo-300">
               <Settings2 className="h-5 w-5" />
+              {needsDeviceLabelSetup(getLocalDeviceIdentity()) && (
+                <span
+                  className="absolute -right-0.5 -top-0.5 h-2.5 w-2.5 rounded-full bg-destructive"
+                  aria-hidden="true"
+                />
+              )}
             </div>
             <div className="space-y-1">
-              <p className="font-medium">Preferències globals</p>
+              <p className="font-medium flex items-center gap-2">
+                Preferències globals
+                {needsDeviceLabelSetup(getLocalDeviceIdentity()) && (
+                  <span className="inline-flex items-center rounded-full bg-destructive/10 px-2 py-0.5 text-xs font-medium text-destructive">
+                    Pendent
+                  </span>
+                )}
+              </p>
               <p className="text-sm text-muted-foreground">
                 Aquestes opcions s'apliquen al dispositiu actual. No canvien les dades dels grups ni es comparteixen amb altres persones.
               </p>

--- a/src/features/groups/Preferences.tsx
+++ b/src/features/groups/Preferences.tsx
@@ -136,7 +136,12 @@ function DeviceIdentityCard() {
 
         <div className="space-y-1.5">
           <Label htmlFor="device-id">Id del dispositiu</Label>
-          <Input id="device-id" value={identity.deviceId} readOnly className="font-mono text-xs" />
+          <div
+            id="device-id"
+            className="rounded-md border bg-muted/40 px-3 py-2 font-mono text-xs text-muted-foreground break-all"
+          >
+            {identity.deviceId}
+          </div>
         </div>
 
         <div className="space-y-1.5">

--- a/src/features/groups/Preferences.tsx
+++ b/src/features/groups/Preferences.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { ArrowLeft, Monitor, Moon, Settings2, Sun, Wifi } from 'lucide-react'
+import { ArrowLeft, Monitor, Moon, Settings2, Smartphone, Sun, Wifi } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -16,6 +16,12 @@ import {
   saveSyncPreferencesDraft,
   type SyncPreferencesDraft,
 } from '@/lib/sync-preferences'
+import {
+  getDefaultDeviceLabel,
+  getLocalDeviceIdentity,
+  resetLocalDeviceLabel,
+  updateLocalDeviceLabel,
+} from '@/lib/device-identity'
 
 const themeOptions = [
   { value: 'light' as const, label: 'Clar', icon: Sun },
@@ -55,6 +61,91 @@ function ThemePreferenceCard() {
           Tema actiu: <strong>{themeOptions.find((option) => option.value === theme)?.label}</strong>
           {theme === 'system' ? `, resolt ara com a ${resolvedTheme === 'dark' ? 'fosc' : 'clar'}` : ''}.
         </p>
+      </CardContent>
+    </Card>
+  )
+}
+
+function DeviceIdentityCard() {
+  const [identity, setIdentity] = useState(() => getLocalDeviceIdentity())
+  const [deviceLabel, setDeviceLabel] = useState(identity.deviceLabel)
+  const [status, setStatus] = useState<'idle' | 'saved' | 'reset'>('idle')
+  const statusTimeoutRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (statusTimeoutRef.current !== null) {
+        window.clearTimeout(statusTimeoutRef.current)
+      }
+    }
+  }, [])
+
+  const scheduleStatusReset = () => {
+    if (statusTimeoutRef.current !== null) {
+      window.clearTimeout(statusTimeoutRef.current)
+    }
+
+    statusTimeoutRef.current = window.setTimeout(() => {
+      setStatus('idle')
+      statusTimeoutRef.current = null
+    }, 2000)
+  }
+
+  const handleSave = () => {
+    const next = updateLocalDeviceLabel(deviceLabel)
+    setIdentity(next)
+    setDeviceLabel(next.deviceLabel)
+    setStatus('saved')
+    scheduleStatusReset()
+  }
+
+  const handleReset = () => {
+    const next = resetLocalDeviceLabel()
+    setIdentity(next)
+    setDeviceLabel(next.deviceLabel)
+    setStatus('reset')
+    scheduleStatusReset()
+  }
+
+  const defaultLabel = getDefaultDeviceLabel(identity.deviceId)
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base flex items-center gap-2">
+          <Smartphone className="h-4 w-4" />
+          Aquest dispositiu
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        <p className="text-sm text-muted-foreground">
+          Aquesta identitat és local al dispositiu actual. L’id és estable i el nom es pot editar per fer-lo més reconeixible quan arribi a activitat o sync.
+        </p>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="device-id">Id del dispositiu</Label>
+          <Input id="device-id" value={identity.deviceId} readOnly className="font-mono text-xs" />
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="device-label">Nom del dispositiu</Label>
+          <Input
+            id="device-label"
+            value={deviceLabel}
+            onChange={(e) => setDeviceLabel(e.target.value)}
+            placeholder={defaultLabel}
+          />
+          <p className="text-xs text-muted-foreground">
+            Si el deixes buit, es farà servir un fallback distingible com <strong>{defaultLabel}</strong>.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <Button type="button" onClick={handleSave}>Desar nom</Button>
+          <Button type="button" variant="outline" onClick={handleReset}>Restaurar fallback</Button>
+          {status === 'saved' && <p className="text-sm text-success self-center">Nom del dispositiu desat.</p>}
+          {status === 'reset' && <p className="text-sm text-success self-center">Fallback restaurat.</p>}
+        </div>
       </CardContent>
     </Card>
   )
@@ -240,6 +331,8 @@ export function Preferences() {
       </Card>
 
       <ThemePreferenceCard />
+
+      <DeviceIdentityCard />
 
       <Card>
         <CardHeader>

--- a/src/features/groups/Preferences.tsx
+++ b/src/features/groups/Preferences.tsx
@@ -109,7 +109,11 @@ function DeviceIdentityCard() {
   }
 
   const defaultLabel = getDefaultDeviceLabel(identity.deviceId)
-  const needsSetup = needsDeviceLabelSetup(identity)
+  const previewIdentity = {
+    ...identity,
+    deviceLabel: deviceLabel.trim() || defaultLabel,
+  }
+  const needsSetup = needsDeviceLabelSetup(previewIdentity)
 
   return (
     <Card className={needsSetup ? 'border-amber-300 bg-amber-50/40 dark:border-amber-800 dark:bg-amber-950/20' : undefined}>

--- a/src/features/groups/Preferences.tsx
+++ b/src/features/groups/Preferences.tsx
@@ -67,8 +67,13 @@ function ThemePreferenceCard() {
   )
 }
 
-function DeviceIdentityCard() {
-  const [identity, setIdentity] = useState(() => getLocalDeviceIdentity())
+function DeviceIdentityCard({
+  identity,
+  onIdentityChange,
+}: {
+  identity: ReturnType<typeof getLocalDeviceIdentity>
+  onIdentityChange: (identity: ReturnType<typeof getLocalDeviceIdentity>) => void
+}) {
   const [deviceLabel, setDeviceLabel] = useState(identity.deviceLabel)
   const [status, setStatus] = useState<'idle' | 'saved' | 'reset'>('idle')
   const statusTimeoutRef = useRef<number | null>(null)
@@ -94,7 +99,7 @@ function DeviceIdentityCard() {
 
   const handleSave = () => {
     const next = updateLocalDeviceLabel(deviceLabel)
-    setIdentity(next)
+    onIdentityChange(next)
     setDeviceLabel(next.deviceLabel)
     setStatus('saved')
     scheduleStatusReset()
@@ -102,7 +107,7 @@ function DeviceIdentityCard() {
 
   const handleReset = () => {
     const next = resetLocalDeviceLabel()
-    setIdentity(next)
+    onIdentityChange(next)
     setDeviceLabel(next.deviceLabel)
     setStatus('reset')
     scheduleStatusReset()
@@ -317,6 +322,7 @@ function SyncPreferencesCard() {
 
 export function Preferences() {
   const navigate = useNavigate()
+  const [deviceIdentity, setDeviceIdentity] = useState(() => getLocalDeviceIdentity())
 
   return (
     <div className="max-w-2xl mx-auto p-4 space-y-6">
@@ -340,7 +346,7 @@ export function Preferences() {
           <div className="flex items-start gap-3">
             <div className="relative rounded-full bg-indigo-50 p-2 text-indigo-600 dark:bg-indigo-950 dark:text-indigo-300">
               <Settings2 className="h-5 w-5" />
-              {needsDeviceLabelSetup(getLocalDeviceIdentity()) && (
+              {needsDeviceLabelSetup(deviceIdentity) && (
                 <span
                   className="absolute -right-0.5 -top-0.5 h-2.5 w-2.5 rounded-full bg-destructive"
                   aria-hidden="true"
@@ -350,7 +356,7 @@ export function Preferences() {
             <div className="space-y-1">
               <p className="font-medium flex items-center gap-2">
                 Preferències globals
-                {needsDeviceLabelSetup(getLocalDeviceIdentity()) && (
+                {needsDeviceLabelSetup(deviceIdentity) && (
                   <span className="inline-flex items-center rounded-full bg-destructive/10 px-2 py-0.5 text-xs font-medium text-destructive">
                     Pendent
                   </span>
@@ -366,7 +372,7 @@ export function Preferences() {
 
       <ThemePreferenceCard />
 
-      <DeviceIdentityCard />
+      <DeviceIdentityCard identity={deviceIdentity} onIdentityChange={setDeviceIdentity} />
 
       <Card>
         <CardHeader>

--- a/src/lib/device-identity.ts
+++ b/src/lib/device-identity.ts
@@ -1,0 +1,105 @@
+export interface DeviceIdentity {
+  deviceId: string
+  deviceLabel: string
+}
+
+const STORAGE_KEY = 'reparteix:device-identity:v1'
+const DEVICE_LABEL_PREFIX = 'Dispositiu'
+const DEFAULT_ACTOR = 'local'
+
+function canUseLocalStorage(): boolean {
+  return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined'
+}
+
+function generateDeviceId(): string {
+  return crypto.randomUUID()
+}
+
+function getShortDeviceSuffix(deviceId: string): string {
+  return deviceId.replace(/-/g, '').slice(0, 4).toLowerCase()
+}
+
+export function getDefaultDeviceLabel(deviceId: string): string {
+  return `${DEVICE_LABEL_PREFIX} ${getShortDeviceSuffix(deviceId)}`
+}
+
+function normalizeDeviceIdentity(value: unknown): DeviceIdentity | null {
+  if (!value || typeof value !== 'object') return null
+
+  const candidate = value as Partial<DeviceIdentity>
+  const deviceId = typeof candidate.deviceId === 'string' ? candidate.deviceId.trim() : ''
+  if (!deviceId) return null
+
+  const deviceLabel = typeof candidate.deviceLabel === 'string' && candidate.deviceLabel.trim()
+    ? candidate.deviceLabel.trim()
+    : getDefaultDeviceLabel(deviceId)
+
+  return { deviceId, deviceLabel }
+}
+
+function readStoredDeviceIdentity(): DeviceIdentity | null {
+  if (!canUseLocalStorage()) return null
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    if (!raw) return null
+    return normalizeDeviceIdentity(JSON.parse(raw))
+  } catch {
+    return null
+  }
+}
+
+function persistDeviceIdentity(identity: DeviceIdentity): DeviceIdentity {
+  if (!canUseLocalStorage()) return identity
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(identity))
+  } catch {
+    // ignore persistence failures
+  }
+
+  return identity
+}
+
+export function ensureLocalDeviceIdentity(): DeviceIdentity {
+  const existing = readStoredDeviceIdentity()
+  if (existing) {
+    return persistDeviceIdentity(existing)
+  }
+
+  const deviceId = generateDeviceId()
+  return persistDeviceIdentity({
+    deviceId,
+    deviceLabel: getDefaultDeviceLabel(deviceId),
+  })
+}
+
+export function getLocalDeviceIdentity(): DeviceIdentity {
+  return ensureLocalDeviceIdentity()
+}
+
+export function updateLocalDeviceLabel(nextLabel: string): DeviceIdentity {
+  const current = ensureLocalDeviceIdentity()
+  const trimmed = nextLabel.trim()
+
+  return persistDeviceIdentity({
+    ...current,
+    deviceLabel: trimmed || getDefaultDeviceLabel(current.deviceId),
+  })
+}
+
+export function resetLocalDeviceLabel(): DeviceIdentity {
+  const current = ensureLocalDeviceIdentity()
+  return persistDeviceIdentity({
+    ...current,
+    deviceLabel: getDefaultDeviceLabel(current.deviceId),
+  })
+}
+
+export function getLocalActorLabel(): string {
+  try {
+    return ensureLocalDeviceIdentity().deviceLabel
+  } catch {
+    return DEFAULT_ACTOR
+  }
+}

--- a/src/lib/device-identity.ts
+++ b/src/lib/device-identity.ts
@@ -7,6 +7,8 @@ const STORAGE_KEY = 'reparteix:device-identity:v1'
 const DEVICE_LABEL_PREFIX = 'Dispositiu'
 const DEFAULT_ACTOR = 'local'
 
+let memoryDeviceIdentity: DeviceIdentity | null = null
+
 function canUseLocalStorage(): boolean {
   return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined'
 }
@@ -37,19 +39,35 @@ function normalizeDeviceIdentity(value: unknown): DeviceIdentity | null {
   return { deviceId, deviceLabel }
 }
 
-function readStoredDeviceIdentity(): DeviceIdentity | null {
-  if (!canUseLocalStorage()) return null
+function readStoredDeviceIdentity(): { identity: DeviceIdentity | null, needsRepair: boolean } {
+  if (!canUseLocalStorage()) {
+    return { identity: null, needsRepair: false }
+  }
 
   try {
     const raw = window.localStorage.getItem(STORAGE_KEY)
-    if (!raw) return null
-    return normalizeDeviceIdentity(JSON.parse(raw))
+    if (!raw) {
+      return { identity: null, needsRepair: false }
+    }
+
+    const parsed = JSON.parse(raw) as unknown
+    const identity = normalizeDeviceIdentity(parsed)
+    if (!identity) {
+      return { identity: null, needsRepair: false }
+    }
+
+    const original = parsed as Partial<DeviceIdentity>
+    const needsRepair = original.deviceLabel !== identity.deviceLabel || original.deviceId !== identity.deviceId
+
+    return { identity, needsRepair }
   } catch {
-    return null
+    return { identity: null, needsRepair: false }
   }
 }
 
 function persistDeviceIdentity(identity: DeviceIdentity): DeviceIdentity {
+  memoryDeviceIdentity = identity
+
   if (!canUseLocalStorage()) return identity
 
   try {
@@ -62,9 +80,18 @@ function persistDeviceIdentity(identity: DeviceIdentity): DeviceIdentity {
 }
 
 export function ensureLocalDeviceIdentity(): DeviceIdentity {
-  const existing = readStoredDeviceIdentity()
-  if (existing) {
-    return persistDeviceIdentity(existing)
+  const { identity: storedIdentity, needsRepair } = readStoredDeviceIdentity()
+  if (storedIdentity) {
+    if (needsRepair) {
+      return persistDeviceIdentity(storedIdentity)
+    }
+
+    memoryDeviceIdentity = storedIdentity
+    return storedIdentity
+  }
+
+  if (memoryDeviceIdentity) {
+    return memoryDeviceIdentity
   }
 
   const deviceId = generateDeviceId()
@@ -94,6 +121,14 @@ export function resetLocalDeviceLabel(): DeviceIdentity {
     ...current,
     deviceLabel: getDefaultDeviceLabel(current.deviceId),
   })
+}
+
+export function isDefaultDeviceLabel(deviceLabel: string, deviceId: string): boolean {
+  return deviceLabel.trim() === getDefaultDeviceLabel(deviceId)
+}
+
+export function needsDeviceLabelSetup(identity: DeviceIdentity): boolean {
+  return isDefaultDeviceLabel(identity.deviceLabel, identity.deviceId)
 }
 
 export function getLocalActorLabel(): string {

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -13,7 +13,7 @@ import {
   type SyncReport,
 } from './domain/services'
 import { db } from './infra/db'
-import { getLocalDeviceIdentity, getLocalActorLabel } from './lib/device-identity'
+import { getLocalDeviceIdentity } from './lib/device-identity'
 
 export type { Group, Expense, Payment, Member, ActivityEntry, ActivityAction, Balance, Settlement, NettingResult, GroupExport, ReparteixExportV1, SyncEnvelopeV1, SyncReport }
 export { calculateBalances, calculateSettlements, calculateNetting }
@@ -42,7 +42,7 @@ async function appendActivity(entry: Omit<ActivityEntry, 'id' | 'at' | 'actor'> 
   const activity: ActivityEntry = {
     ...entry,
     id: entry.id ?? generateId(),
-    actor: entry.actor ?? getLocalActorLabel(),
+    actor: entry.actor ?? deviceIdentity.deviceLabel,
     at: entry.at ?? now(),
     meta: {
       ...entry.meta,

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -13,6 +13,7 @@ import {
   type SyncReport,
 } from './domain/services'
 import { db } from './infra/db'
+import { getLocalDeviceIdentity, getLocalActorLabel } from './lib/device-identity'
 
 export type { Group, Expense, Payment, Member, ActivityEntry, ActivityAction, Balance, Settlement, NettingResult, GroupExport, ReparteixExportV1, SyncEnvelopeV1, SyncReport }
 export { calculateBalances, calculateSettlements, calculateNetting }
@@ -37,11 +38,17 @@ function sanitizeActivitySnapshot<T>(value: T): T {
 }
 
 async function appendActivity(entry: Omit<ActivityEntry, 'id' | 'at' | 'actor'> & Partial<Pick<ActivityEntry, 'id' | 'at' | 'actor'>>): Promise<ActivityEntry> {
+  const deviceIdentity = getLocalDeviceIdentity()
   const activity: ActivityEntry = {
     ...entry,
     id: entry.id ?? generateId(),
-    actor: entry.actor ?? 'local',
+    actor: entry.actor ?? getLocalActorLabel(),
     at: entry.at ?? now(),
+    meta: {
+      ...entry.meta,
+      deviceId: deviceIdentity.deviceId,
+      deviceLabel: deviceIdentity.deviceLabel,
+    },
   }
   await db.activity.add(activity)
   return activity


### PR DESCRIPTION
## Què canvia
- afegeix un substrat local d'identitat de dispositiu amb `deviceId` estable i `deviceLabel` editable
- genera un fallback distingible tipus `Dispositiu abcd` quan no hi ha nom explícit
- enriqueix l'activity log amb `deviceId` i `deviceLabel` a `meta`, i fa servir el label com a `actor` local
- exposa el nom i l'id del dispositiu a **Preferències** perquè es pugui editar des d'un lloc estable

## Validació
- npm run build

## Issue relacionada
- closes #164
- relacionat amb #149
