### PR TITLE
fix: make system theme follow OS preference

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { PWAUpdatePrompt } from './components/PWAUpdatePrompt'
 import { PWAInstallPrompt } from './components/PWAInstallPrompt'
 import { Footer } from './components/Footer'
 import { useFileHandler } from './hooks/useFileHandler'
+import { useTheme } from './hooks/useTheme'
 
 const GroupList = lazy(() => import('./features/groups/GroupList').then((m) => ({ default: m.GroupList })))
 const GroupDetail = lazy(() => import('./features/groups/GroupDetail').then((m) => ({ default: m.GroupDetail })))
@@ -44,6 +45,8 @@ function FileHandlerBridge() {
 }
 
 function App() {
+  useTheme()
+
   return (
     <HashRouter>
       <div className="flex min-h-screen flex-col">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,9 +44,12 @@ function FileHandlerBridge() {
   return null
 }
 
-function App() {
+function ThemeBridge() {
   useTheme()
+  return null
+}
 
+function App() {
   return (
     <HashRouter>
       <div className="flex min-h-screen flex-col">
@@ -64,6 +67,7 @@ function App() {
         </Suspense>
         <Footer />
       </div>
+      <ThemeBridge />
       <FileHandlerBridge />
       <PWAInstallPrompt />
       <PWAUpdatePrompt />

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -3,35 +3,41 @@ import { useCallback, useEffect, useSyncExternalStore } from 'react'
 type Theme = 'light' | 'dark' | 'system'
 
 const STORAGE_KEY = 'reparteix-theme'
+const MEDIA_QUERY = '(prefers-color-scheme: dark)'
 
 function getStoredTheme(): Theme {
+  if (typeof window === 'undefined') return 'system'
+
   try {
     const stored = localStorage.getItem(STORAGE_KEY)
     if (stored === 'light' || stored === 'dark' || stored === 'system') return stored
   } catch {
     /* localStorage unavailable */
   }
+
   return 'system'
 }
 
 function getResolvedTheme(theme: Theme): 'light' | 'dark' {
   if (theme === 'system') {
-    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+    if (typeof window === 'undefined') return 'light'
+    return window.matchMedia(MEDIA_QUERY).matches ? 'dark' : 'light'
   }
   return theme
 }
 
 function applyTheme(theme: Theme) {
+  if (typeof document === 'undefined') return
+
   const resolved = getResolvedTheme(theme)
   document.documentElement.classList.toggle('dark', resolved === 'dark')
 }
 
-// --- tiny external store so all consumers stay in sync ---
-let currentTheme: Theme = getStoredTheme()
+let currentTheme: Theme = typeof window === 'undefined' ? 'system' : getStoredTheme()
 const listeners = new Set<() => void>()
 
 function emit() {
-  listeners.forEach((l) => l())
+  listeners.forEach((listener) => listener())
 }
 
 function subscribe(listener: () => void) {
@@ -45,25 +51,28 @@ function getSnapshot(): Theme {
   return currentTheme
 }
 
-// Apply on module load so there's no flash of wrong theme
-applyTheme(currentTheme)
-
-// Listen for system preference changes
-if (typeof window !== 'undefined') {
-  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
-    if (currentTheme === 'system') {
-      applyTheme('system')
-      emit()
-    }
-  })
-}
-
 export function useTheme() {
-  const theme = useSyncExternalStore(subscribe, getSnapshot)
+  const theme = useSyncExternalStore<Theme>(subscribe, getSnapshot, () => 'system')
 
   useEffect(() => {
     applyTheme(theme)
   }, [theme])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    const media = window.matchMedia(MEDIA_QUERY)
+    const handleChange = () => {
+      if (currentTheme === 'system') {
+        applyTheme('system')
+        emit()
+      }
+    }
+
+    applyTheme(currentTheme)
+    media.addEventListener('change', handleChange)
+    return () => media.removeEventListener('change', handleChange)
+  }, [])
 
   const setTheme = useCallback((next: Theme) => {
     currentTheme = next

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useSyncExternalStore } from 'react'
+import { useCallback, useLayoutEffect, useSyncExternalStore } from 'react'
 
 type Theme = 'light' | 'dark' | 'system'
 
@@ -35,15 +35,38 @@ function applyTheme(theme: Theme) {
 
 let currentTheme: Theme = typeof window === 'undefined' ? 'system' : getStoredTheme()
 const listeners = new Set<() => void>()
+let mediaQueryCleanup: (() => void) | null = null
 
 function emit() {
   listeners.forEach((listener) => listener())
 }
 
+function ensureSystemThemeListener() {
+  if (typeof window === 'undefined' || mediaQueryCleanup) return
+
+  const media = window.matchMedia(MEDIA_QUERY)
+  const handleChange = () => {
+    if (currentTheme === 'system') {
+      applyTheme('system')
+      emit()
+    }
+  }
+
+  media.addEventListener('change', handleChange)
+  mediaQueryCleanup = () => {
+    media.removeEventListener('change', handleChange)
+    mediaQueryCleanup = null
+  }
+}
+
 function subscribe(listener: () => void) {
   listeners.add(listener)
+  ensureSystemThemeListener()
   return () => {
     listeners.delete(listener)
+    if (listeners.size === 0 && mediaQueryCleanup) {
+      mediaQueryCleanup()
+    }
   }
 }
 
@@ -54,25 +77,9 @@ function getSnapshot(): Theme {
 export function useTheme() {
   const theme = useSyncExternalStore<Theme>(subscribe, getSnapshot, () => 'system')
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     applyTheme(theme)
   }, [theme])
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return
-
-    const media = window.matchMedia(MEDIA_QUERY)
-    const handleChange = () => {
-      if (currentTheme === 'system') {
-        applyTheme('system')
-        emit()
-      }
-    }
-
-    applyTheme(currentTheme)
-    media.addEventListener('change', handleChange)
-    return () => media.removeEventListener('change', handleChange)
-  }, [])
 
   const setTheme = useCallback((next: Theme) => {
     currentTheme = next


### PR DESCRIPTION
## Què canvia
- reforça la detecció del tema del sistema quan l'opció activa és `Sistema`
- evita dependència de side effects al carregar el mòdul
- escolta els canvis de `prefers-color-scheme` de manera més robusta

## Validació
- npm run build
