### PR TITLE
feat: show activity origin in history UI

### DIFF
--- a/src/features/groups/ItemActivityDialog.tsx
+++ b/src/features/groups/ItemActivityDialog.tsx
@@ -1,5 +1,6 @@
 import type { ActivityEntry, Group } from '@/domain'
 import { Badge } from '@/components/ui/badge'
+import { getLocalDeviceIdentity } from '@/lib/device-identity'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -10,7 +11,7 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog'
-import { buildMemberMap, formatActivityTimestamp, getActivityDiffLines } from './activity-utils'
+import { buildMemberMap, formatActivityTimestamp, getActivityDiffLines, getActivityOriginSummary } from './activity-utils'
 
 interface ItemActivityDialogProps {
   group: Group
@@ -21,6 +22,13 @@ interface ItemActivityDialogProps {
 
 export function ItemActivityDialog({ group, title, entries, children }: ItemActivityDialogProps) {
   const memberMap = buildMemberMap(group)
+  const localDeviceId = (() => {
+    try {
+      return getLocalDeviceIdentity().deviceId
+    } catch {
+      return undefined
+    }
+  })()
 
   return (
     <AlertDialog>
@@ -36,11 +44,20 @@ export function ItemActivityDialog({ group, title, entries, children }: ItemActi
         <div className="max-h-[50vh] space-y-3 overflow-y-auto">
           {entries.map((entry) => {
             const diffLines = getActivityDiffLines(entry, memberMap, group.currency)
+            const origin = getActivityOriginSummary(entry, localDeviceId)
             return (
               <div key={entry.id} className="rounded-lg border p-3">
                 <div className="mb-2 flex items-center justify-between gap-3">
                   <Badge variant="outline">{entry.action.replace(/^.*\./, '')}</Badge>
                   <span className="text-xs text-muted-foreground">{formatActivityTimestamp(entry.at)}</span>
+                </div>
+                <div className="mb-2 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                  <span>Origen: <span className="font-medium text-foreground">{origin.label}</span></span>
+                  {origin.detail && (
+                    <span className="rounded-full bg-muted px-2 py-0.5 text-[11px]">
+                      {origin.detail}
+                    </span>
+                  )}
                 </div>
                 {diffLines.length > 0 ? (
                   <ul className="space-y-1 text-sm text-muted-foreground">

--- a/src/features/groups/activity-utils.test.ts
+++ b/src/features/groups/activity-utils.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import type { ActivityEntry } from '@/domain'
+import { getActivityOriginSummary } from './activity-utils'
+
+function buildEntry(overrides: Partial<ActivityEntry> = {}): ActivityEntry {
+  return {
+    id: 'entry-1',
+    groupId: 'group-1',
+    entityType: 'expense',
+    entityId: 'expense-1',
+    action: 'expense.updated',
+    actor: 'local',
+    at: '2026-04-24T18:00:00.000Z',
+    ...overrides,
+  }
+}
+
+describe('getActivityOriginSummary', () => {
+  it('tradueix el dispositiu local a copy contextual', () => {
+    const summary = getActivityOriginSummary(buildEntry({
+      actor: 'Dispositiu abcd',
+      meta: {
+        deviceId: 'abcd-1234',
+        deviceLabel: 'Dispositiu abcd',
+      },
+    }), 'abcd-1234')
+
+    expect(summary).toMatchObject({
+      label: 'Aquest dispositiu',
+      detail: 'Dispositiu abcd',
+      isLocal: true,
+      isResolved: true,
+    })
+  })
+
+  it('manté autoria remota amb pista tècnica curta', () => {
+    const summary = getActivityOriginSummary(buildEntry({
+      actor: 'Portàtil Edu',
+      meta: {
+        deviceId: 'f1e2-d3c4',
+        deviceLabel: 'Portàtil Edu',
+      },
+    }))
+
+    expect(summary).toMatchObject({
+      label: 'Portàtil Edu',
+      detail: 'id f1e2',
+      isLocal: false,
+      isResolved: true,
+    })
+  })
+
+  it('deriva un fallback llegible si només hi ha deviceId', () => {
+    const summary = getActivityOriginSummary(buildEntry({
+      meta: {
+        deviceId: '9988-7766',
+      },
+    }))
+
+    expect(summary).toMatchObject({
+      label: 'Dispositiu 9988',
+      detail: 'id 9988',
+      isResolved: true,
+    })
+  })
+
+  it('fa fallback explícit quan no hi ha autoria resolta', () => {
+    const summary = getActivityOriginSummary(buildEntry())
+
+    expect(summary).toMatchObject({
+      label: 'Origen no resolt',
+      detail: null,
+      isLocal: false,
+      isResolved: false,
+    })
+  })
+})

--- a/src/features/groups/activity-utils.ts
+++ b/src/features/groups/activity-utils.ts
@@ -1,4 +1,5 @@
 import type { ActivityEntry, Group } from '@/domain'
+import { getDefaultDeviceLabel, getShortDeviceSuffix } from '@/lib/device-identity'
 
 type Snapshot = Record<string, unknown>
 type ActivityMeta = Record<string, unknown>
@@ -137,10 +138,6 @@ function readMetaString(meta: unknown, key: string): string | null {
   return typeof value === 'string' && value.trim() ? value.trim() : null
 }
 
-function getShortDeviceSuffix(deviceId: string): string {
-  return deviceId.replace(/-/g, '').slice(0, 4).toLowerCase()
-}
-
 export interface ActivityOriginSummary {
   label: string
   detail: string | null
@@ -154,7 +151,7 @@ export function getActivityOriginSummary(entry: ActivityEntry, localDeviceId?: s
     : null
   const deviceId = readMetaString(entry.meta, 'deviceId')
   const deviceLabel = readMetaString(entry.meta, 'deviceLabel')
-  const fallbackDeviceLabel = deviceId ? `Dispositiu ${getShortDeviceSuffix(deviceId)}` : null
+  const fallbackDeviceLabel = deviceId ? getDefaultDeviceLabel(deviceId) : null
   const resolvedLabel = actor ?? deviceLabel ?? fallbackDeviceLabel
 
   if (localDeviceId && deviceId === localDeviceId) {

--- a/src/features/groups/activity-utils.ts
+++ b/src/features/groups/activity-utils.ts
@@ -1,6 +1,7 @@
 import type { ActivityEntry, Group } from '@/domain'
 
 type Snapshot = Record<string, unknown>
+type ActivityMeta = Record<string, unknown>
 
 const CURRENCY_SYMBOLS: Record<string, string> = {
   EUR: '€',
@@ -128,4 +129,56 @@ export function formatActivityTimestamp(at: string): string {
     hour: '2-digit',
     minute: '2-digit',
   })
+}
+
+function readMetaString(meta: unknown, key: string): string | null {
+  if (!meta || typeof meta !== 'object') return null
+  const value = (meta as ActivityMeta)[key]
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function getShortDeviceSuffix(deviceId: string): string {
+  return deviceId.replace(/-/g, '').slice(0, 4).toLowerCase()
+}
+
+export interface ActivityOriginSummary {
+  label: string
+  detail: string | null
+  isLocal: boolean
+  isResolved: boolean
+}
+
+export function getActivityOriginSummary(entry: ActivityEntry, localDeviceId?: string): ActivityOriginSummary {
+  const actor = typeof entry.actor === 'string' && entry.actor.trim() && entry.actor.trim() !== 'local'
+    ? entry.actor.trim()
+    : null
+  const deviceId = readMetaString(entry.meta, 'deviceId')
+  const deviceLabel = readMetaString(entry.meta, 'deviceLabel')
+  const fallbackDeviceLabel = deviceId ? `Dispositiu ${getShortDeviceSuffix(deviceId)}` : null
+  const resolvedLabel = actor ?? deviceLabel ?? fallbackDeviceLabel
+
+  if (localDeviceId && deviceId === localDeviceId) {
+    return {
+      label: 'Aquest dispositiu',
+      detail: resolvedLabel && resolvedLabel !== 'Aquest dispositiu' ? resolvedLabel : null,
+      isLocal: true,
+      isResolved: true,
+    }
+  }
+
+  if (resolvedLabel) {
+    return {
+      label: resolvedLabel,
+      detail: deviceId ? `id ${getShortDeviceSuffix(deviceId)}` : null,
+      isLocal: false,
+      isResolved: true,
+    }
+  }
+
+  return {
+    label: 'Origen no resolt',
+    detail: null,
+    isLocal: false,
+    isResolved: false,
+  }
 }

--- a/src/lib/device-identity.ts
+++ b/src/lib/device-identity.ts
@@ -17,7 +17,7 @@ function generateDeviceId(): string {
   return crypto.randomUUID()
 }
 
-function getShortDeviceSuffix(deviceId: string): string {
+export function getShortDeviceSuffix(deviceId: string): string {
   return deviceId.replace(/-/g, '').slice(0, 4).toLowerCase()
 }
 


### PR DESCRIPTION
Closes #149

## Què canvia
- mostra l'origen de cada canvi a l'historial d'elements
- tradueix el dispositiu local a "Aquest dispositiu" quan toca
- afegeix fallbacks explícits i tests per la resolució d'autoria/dispositiu

## Validació
- npm test -- src/features/groups/activity-utils.test.ts
- npm run typecheck
- npm run build