### PR TITLE
feat: refine group list actions

### DIFF
--- a/src/features/groups/GroupList.tsx
+++ b/src/features/groups/GroupList.tsx
@@ -20,12 +20,6 @@ import {
 } from '@/components/ui/alert-dialog'
 import { getLocalDeviceIdentity, needsDeviceLabelSetup } from '@/lib/device-identity'
 
-const CURRENCY_SYMBOLS: Record<string, string> = {
-  EUR: '€',
-  USD: '$',
-  GBP: '£',
-}
-
 export function GroupList() {
   const { groups, groupTotals, loadGroups, addGroup, deleteGroup, importGroup } = useStore()
   const hasPendingDeviceSetup = needsDeviceLabelSetup(getLocalDeviceIdentity())
@@ -104,7 +98,6 @@ export function GroupList() {
 
   const renderGroupCard = (group: (typeof groups)[number]) => {
     const total = groupTotals[group.id] ?? 0
-    const currencySymbol = CURRENCY_SYMBOLS[group.currency] ?? group.currency
 
     return (
     <Card
@@ -139,7 +132,7 @@ export function GroupList() {
           <div className="w-20 shrink-0 self-center text-right">
             {total > 0 && (
               <span className="text-xs text-muted-foreground whitespace-nowrap">
-                {total.toFixed(2)}&nbsp;{currencySymbol}
+                {total.toFixed(2)}&nbsp;{group.currency}
               </span>
             )}
           </div>

--- a/src/features/groups/GroupList.tsx
+++ b/src/features/groups/GroupList.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { useStore } from '../../store'
 import { useNavigate } from 'react-router-dom'
-import { Plus, Trash2, Users, ChevronRight, Upload, Archive, ChevronDown, Settings, MoreHorizontal } from 'lucide-react'
+import { Plus, Trash2, Users, Upload, Archive, ChevronDown, Settings, MoreHorizontal } from 'lucide-react'
 import { ONBOARDING_COMPLETED_KEY } from './OnboardingWizard'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
@@ -136,17 +136,16 @@ export function GroupList() {
               {group.members.filter((m) => !m.deleted).length} membres
             </p>
           </div>
-          <div className="shrink-0 flex flex-col items-end gap-1 text-right">
+          <div className="w-20 shrink-0 self-center text-right">
             {total > 0 && (
-              <span className="text-xs text-muted-foreground max-w-[88px] break-words">
+              <span className="text-xs text-muted-foreground whitespace-nowrap">
                 {total.toFixed(2)}&nbsp;{currencySymbol}
               </span>
             )}
           </div>
-          <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
         </button>
 
-        <div className="relative shrink-0">
+        <div className="relative shrink-0 self-center">
           <Button
             variant="ghost"
             size="icon"

--- a/src/features/groups/GroupList.tsx
+++ b/src/features/groups/GroupList.tsx
@@ -1,13 +1,12 @@
 import { useEffect, useRef, useState } from 'react'
 import { useStore } from '../../store'
 import { useNavigate } from 'react-router-dom'
-import { Plus, Trash2, Users, ChevronRight, Upload, Archive, ChevronDown, Settings } from 'lucide-react'
+import { Plus, Trash2, Users, ChevronRight, Upload, Archive, ChevronDown, Settings, MoreHorizontal } from 'lucide-react'
 import { ONBOARDING_COMPLETED_KEY } from './OnboardingWizard'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Badge } from '@/components/ui/badge'
-import { Separator } from '@/components/ui/separator'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -29,6 +28,7 @@ export function GroupList() {
   const [importStatus, setImportStatus] = useState<'idle' | 'ok' | 'error'>('idle')
   const [importError, setImportError] = useState('')
   const [showArchived, setShowArchived] = useState(false)
+  const [openGroupMenuId, setOpenGroupMenuId] = useState<string | null>(null)
   const [onboardingCompleted] = useState(() => {
     try {
       return localStorage.getItem(ONBOARDING_COMPLETED_KEY) === 'true'
@@ -49,6 +49,12 @@ export function GroupList() {
       createGroupInputRef.current?.focus()
     }
   }, [showForm])
+
+  useEffect(() => {
+    const handleDocumentClick = () => setOpenGroupMenuId(null)
+    document.addEventListener('click', handleDocumentClick)
+    return () => document.removeEventListener('click', handleDocumentClick)
+  }, [])
 
   const handleCancel = () => {
     setShowForm(false)
@@ -95,7 +101,7 @@ export function GroupList() {
       key={group.id}
       className={`hover:shadow-md transition-shadow duration-150 ${group.archived ? 'opacity-70' : ''}`}
     >
-      <div className="flex items-stretch p-4 gap-2">
+      <div className="flex items-start gap-3 p-4">
         <button
           onClick={() => navigate(`/group/${group.id}`)}
           className="min-w-0 flex-1 text-left flex items-center gap-3"
@@ -130,36 +136,84 @@ export function GroupList() {
           </div>
           <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
         </button>
-        <Separator orientation="vertical" className="h-auto self-stretch" />
-        <AlertDialog>
-          <AlertDialogTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon"
-              aria-label="Eliminar grup"
-              className="shrink-0 self-center text-muted-foreground hover:text-destructive"
+
+        <div className="relative shrink-0">
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Més accions del grup"
+            aria-haspopup="menu"
+            aria-expanded={openGroupMenuId === group.id}
+            aria-controls={`group-actions-${group.id}`}
+            className="text-muted-foreground"
+            onClick={(e) => {
+              e.stopPropagation()
+              setOpenGroupMenuId((current) => (current === group.id ? null : group.id))
+            }}
+          >
+            <MoreHorizontal className="h-4 w-4" />
+          </Button>
+
+          {openGroupMenuId === group.id && (
+            <div
+              id={`group-actions-${group.id}`}
+              role="menu"
+              aria-label={`Accions per a ${group.name}`}
+              className="absolute right-0 top-10 z-20 min-w-[11rem] rounded-xl border bg-popover p-1 shadow-lg"
+              onClick={(e) => e.stopPropagation()}
+              onKeyDown={(e) => {
+                if (e.key === 'Escape') {
+                  e.stopPropagation()
+                  setOpenGroupMenuId(null)
+                }
+              }}
             >
-              <Trash2 className="h-4 w-4" />
-            </Button>
-          </AlertDialogTrigger>
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              <AlertDialogTitle>Eliminar grup</AlertDialogTitle>
-              <AlertDialogDescription>
-                Estàs segur que vols eliminar el grup &quot;{group.name}&quot;? Aquesta acció no es pot desfer.
-              </AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogCancel>Cancel·lar</AlertDialogCancel>
-              <AlertDialogAction
-                onClick={() => deleteGroup(group.id)}
-                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              <button
+                type="button"
+                role="menuitem"
+                onClick={() => {
+                  setOpenGroupMenuId(null)
+                  navigate(`/group/${group.id}/settings`)
+                }}
+                className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-foreground hover:bg-muted"
               >
-                Eliminar
-              </AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
+                <Settings className="h-4 w-4" />
+                Configuració
+              </button>
+
+              <AlertDialog>
+                <AlertDialogTrigger asChild>
+                  <button
+                    type="button"
+                    role="menuitem"
+                    onClick={() => setOpenGroupMenuId(null)}
+                    className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-destructive hover:bg-muted"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                    Eliminar
+                  </button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>Eliminar grup</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      Estàs segur que vols eliminar el grup &quot;{group.name}&quot;? Aquesta acció no es pot desfer.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>Cancel·lar</AlertDialogCancel>
+                    <AlertDialogAction
+                      onClick={() => deleteGroup(group.id)}
+                      className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                    >
+                      Eliminar
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+            </div>
+          )}
+        </div>
       </div>
     </Card>
   )

--- a/src/features/groups/GroupList.tsx
+++ b/src/features/groups/GroupList.tsx
@@ -129,10 +129,15 @@ export function GroupList() {
               {group.members.filter((m) => !m.deleted).length} membres
             </p>
           </div>
-          <div className="w-20 shrink-0 self-center text-right">
+          <div className="w-24 shrink-0 self-center text-right">
             {total > 0 && (
-              <span className="text-xs text-muted-foreground whitespace-nowrap">
-                {total.toFixed(2)}&nbsp;{group.currency}
+              <span className="inline-flex items-baseline justify-end gap-1 whitespace-nowrap">
+                <span className="text-base font-semibold tracking-tight text-foreground">
+                  {total.toFixed(2)}
+                </span>
+                <span className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                  {group.currency}
+                </span>
               </span>
             )}
           </div>

--- a/src/features/groups/GroupList.tsx
+++ b/src/features/groups/GroupList.tsx
@@ -129,13 +129,13 @@ export function GroupList() {
               {group.members.filter((m) => !m.deleted).length} membres
             </p>
           </div>
-          <div className="w-24 shrink-0 self-center text-right">
+          <div className="w-20 shrink-0 self-center text-right">
             {total > 0 && (
-              <span className="inline-flex items-baseline justify-end gap-1 whitespace-nowrap">
-                <span className="text-base font-semibold tracking-tight text-foreground">
+              <span className="inline-flex items-baseline justify-end gap-1 whitespace-nowrap text-sm">
+                <span className="font-medium text-foreground/90">
                   {total.toFixed(2)}
                 </span>
-                <span className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                <span className="text-xs text-muted-foreground">
                   {group.currency}
                 </span>
               </span>

--- a/src/features/groups/GroupList.tsx
+++ b/src/features/groups/GroupList.tsx
@@ -20,6 +20,12 @@ import {
 } from '@/components/ui/alert-dialog'
 import { getLocalDeviceIdentity, needsDeviceLabelSetup } from '@/lib/device-identity'
 
+const CURRENCY_SYMBOLS: Record<string, string> = {
+  EUR: '€',
+  USD: '$',
+  GBP: '£',
+}
+
 export function GroupList() {
   const { groups, groupTotals, loadGroups, addGroup, deleteGroup, importGroup } = useStore()
   const hasPendingDeviceSetup = needsDeviceLabelSetup(getLocalDeviceIdentity())
@@ -96,7 +102,11 @@ export function GroupList() {
   const archivedGroups = groups.filter((g) => g.archived)
   const hasGroups = groups.length > 0
 
-  const renderGroupCard = (group: (typeof groups)[number]) => (
+  const renderGroupCard = (group: (typeof groups)[number]) => {
+    const total = groupTotals[group.id] ?? 0
+    const currencySymbol = CURRENCY_SYMBOLS[group.currency] ?? group.currency
+
+    return (
     <Card
       key={group.id}
       className={`hover:shadow-md transition-shadow duration-150 ${group.archived ? 'opacity-70' : ''}`}
@@ -127,10 +137,9 @@ export function GroupList() {
             </p>
           </div>
           <div className="shrink-0 flex flex-col items-end gap-1 text-right">
-            <Badge variant="secondary">{group.currency}</Badge>
-            {(groupTotals[group.id] ?? 0) > 0 && (
+            {total > 0 && (
               <span className="text-xs text-muted-foreground max-w-[88px] break-words">
-                {groupTotals[group.id].toFixed(2)}&nbsp;{group.currency}
+                {total.toFixed(2)}&nbsp;{currencySymbol}
               </span>
             )}
           </div>
@@ -216,7 +225,8 @@ export function GroupList() {
         </div>
       </div>
     </Card>
-  )
+    )
+  }
 
   return (
     <div className="min-h-screen bg-muted/50">


### PR DESCRIPTION
## Resum\n- compacta les accions de cada targeta de grup dins un menú d'accions\n- manté l'entrada principal enfocada a obrir el grup i deixa un espai clar per afegir noves accions com duplicar\n- afegeix accés directe a configuració des de la llista\n\n## Validació\n- npm run build\n\nRefs #153