### PR TITLE
fix: avoid sync error after successful peer disconnect

### DIFF
--- a/src/infra/sync/sync-session.ts
+++ b/src/infra/sync/sync-session.ts
@@ -126,6 +126,7 @@ export function createSyncSession(
   const MAX_INCOMING_TRANSFER_AGE_MS = 60_000
   let outgoingTransferInFlight = false
   let incomingTransferInFlight = false
+  let hadLocalGroupAtSessionStart: boolean | null = null
   const peerSyncState = new Map<string, {
     localDataSent: boolean
     localDataApplied: boolean
@@ -392,6 +393,11 @@ export function createSyncSession(
     update({ message: 'Preparant dades per enviar…' })
 
     try {
+      if (hadLocalGroupAtSessionStart === false) {
+        conn.send(createSyncAckMessage(groupId, 'no-data'))
+        return
+      }
+
       // Build envelope from local data
       const envelope = await buildEnvelope()
       if (!envelope) {
@@ -559,6 +565,14 @@ export function createSyncSession(
 
   // ─── Helpers ──────────────────────────────────────────────────────────
 
+  async function loadLocalGroupExists(): Promise<boolean> {
+    try {
+      return (await reparteix.getGroup(groupId)) !== null
+    } catch {
+      return false
+    }
+  }
+
   async function buildEnvelope(): Promise<SyncEnvelopeV1 | null> {
     try {
       const group = await reparteix.getGroup(groupId)
@@ -616,6 +630,7 @@ export function createSyncSession(
       })
 
       try {
+        hadLocalGroupAtSessionStart = await loadLocalGroupExists()
         const roomPeerId = await buildGroupPeerId()
         const peerId = await peerManager.init(roomPeerId)
         update({
@@ -641,6 +656,7 @@ export function createSyncSession(
       })
 
       try {
+        hadLocalGroupAtSessionStart = await loadLocalGroupExists()
         await peerManager.init()
         update({
           state: 'connecting',
@@ -671,6 +687,7 @@ export function createSyncSession(
       })
 
       try {
+        hadLocalGroupAtSessionStart = await loadLocalGroupExists()
         const peerId = await peerManager.init(roomPeerId)
         update({
           state: 'waiting-for-peer',
@@ -688,6 +705,7 @@ export function createSyncSession(
       }
 
       try {
+        hadLocalGroupAtSessionStart = await loadLocalGroupExists()
         await peerManager.init()
         update({
           state: 'connecting',
@@ -704,6 +722,7 @@ export function createSyncSession(
 
     /** Clean up all resources. */
     destroy() {
+      hadLocalGroupAtSessionStart = null
       peerSyncState.clear()
       peerManager.destroy()
       listeners.clear()

--- a/src/infra/sync/sync-session.ts
+++ b/src/infra/sync/sync-session.ts
@@ -131,6 +131,7 @@ export function createSyncSession(
     localDataSent: boolean
     localDataApplied: boolean
     remoteAppliedLocalData: boolean
+    remoteHadNoData: boolean
   }>()
   const incomingPayloadChunks = new Map<string, {
     remotePeerId: string
@@ -168,6 +169,7 @@ export function createSyncSession(
       localDataSent: false,
       localDataApplied: false,
       remoteAppliedLocalData: false,
+      remoteHadNoData: false,
     }
     peerSyncState.set(remotePeerId, created)
     return created
@@ -470,11 +472,13 @@ export function createSyncSession(
           syncState.remoteAppliedLocalData = true
         }
 
-        if (syncState?.localDataApplied) {
+        if (syncState?.localDataApplied || syncState?.remoteHadNoData) {
           update({
             state: 'completed',
             lastSuccessAt: new Date().toISOString(),
-            message: 'Sincronització completada. Els dos dispositius ja estan al dia.',
+            message: syncState?.localDataApplied
+              ? 'Sincronització completada. Els dos dispositius ja estan al dia.'
+              : 'Sincronització completada. L’altre dispositiu ha aplicat les dades i no tenia canvis addicionals per enviar.',
           })
           return
         }
@@ -485,7 +489,11 @@ export function createSyncSession(
       }
     } else if (message.status === 'no-data') {
       if (status.state === 'syncing') {
-        if (syncState?.localDataApplied || syncState?.localDataSent) {
+        if (syncState) {
+          syncState.remoteHadNoData = true
+        }
+
+        if (syncState?.localDataApplied || syncState?.localDataSent || syncState?.remoteAppliedLocalData) {
           update({
             state: 'completed',
             lastSuccessAt: new Date().toISOString(),

--- a/src/infra/sync/sync-session.ts
+++ b/src/infra/sync/sync-session.ts
@@ -126,7 +126,11 @@ export function createSyncSession(
   const MAX_INCOMING_TRANSFER_AGE_MS = 60_000
   let outgoingTransferInFlight = false
   let incomingTransferInFlight = false
-  const peerSyncState = new Map<string, { localDataSent: boolean; localDataApplied: boolean }>()
+  const peerSyncState = new Map<string, {
+    localDataSent: boolean
+    localDataApplied: boolean
+    remoteAppliedLocalData: boolean
+  }>()
   const incomingPayloadChunks = new Map<string, {
     remotePeerId: string
     groupId: string
@@ -159,7 +163,11 @@ export function createSyncSession(
     const existing = peerSyncState.get(remotePeerId)
     if (existing) return existing
 
-    const created = { localDataSent: false, localDataApplied: false }
+    const created = {
+      localDataSent: false,
+      localDataApplied: false,
+      remoteAppliedLocalData: false,
+    }
     peerSyncState.set(remotePeerId, created)
     return created
   }
@@ -452,6 +460,10 @@ export function createSyncSession(
 
     if (message.status === 'ok') {
       if (status.state === 'syncing') {
+        if (syncState) {
+          syncState.remoteAppliedLocalData = true
+        }
+
         if (syncState?.localDataApplied) {
           update({
             state: 'completed',
@@ -498,6 +510,7 @@ export function createSyncSession(
   }
 
   function handlePeerDisconnected(remotePeerId: string) {
+    const syncState = peerSyncState.get(remotePeerId)
     peerSyncState.delete(remotePeerId)
     removeRemotePeer(remotePeerId)
     for (const [key, transfer] of incomingPayloadChunks.entries()) {
@@ -509,6 +522,23 @@ export function createSyncSession(
       const wasTransferring = outgoingTransferInFlight || incomingTransferInFlight
       outgoingTransferInFlight = false
       incomingTransferInFlight = false
+
+      const canTreatAsCompleted = !wasTransferring && (
+        syncState?.localDataApplied ||
+        syncState?.remoteAppliedLocalData
+      )
+
+      if (canTreatAsCompleted) {
+        update({
+          state: 'completed',
+          lastSuccessAt: new Date().toISOString(),
+          message: syncState?.localDataApplied
+            ? 'Sincronització completada. L’altre dispositiu ha tancat la sessió després d’aplicar els canvis.'
+            : 'Sincronització completada. L’altre dispositiu ha rebut i aplicat les dades abans de tancar la sessió.',
+        })
+        return
+      }
+
       update({
         state: 'error',
         error: wasTransferring


### PR DESCRIPTION
## Summary\n- treat peer disconnect as success when the sync had already been applied or acknowledged\n- keep disconnects during active transfer as errors\n- preserve the per-peer sync state long enough to decide the final outcome correctly\n\nCloses #171\n