### PR TITLE
feat: duplicate groups as a starting point

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { useTheme } from './hooks/useTheme'
 const GroupList = lazy(() => import('./features/groups/GroupList').then((m) => ({ default: m.GroupList })))
 const GroupDetail = lazy(() => import('./features/groups/GroupDetail').then((m) => ({ default: m.GroupDetail })))
 const GroupSettings = lazy(() => import('./features/groups/GroupSettings').then((m) => ({ default: m.GroupSettings })))
+const DuplicateGroup = lazy(() => import('./features/groups/DuplicateGroup').then((m) => ({ default: m.DuplicateGroup })))
 const Preferences = lazy(() => import('./features/groups/Preferences').then((m) => ({ default: m.Preferences })))
 const ImportFromUrl = lazy(() => import('./features/groups/ImportFromUrl').then((m) => ({ default: m.ImportFromUrl })))
 const OnboardingWizard = lazy(() => import('./features/groups/OnboardingWizard').then((m) => ({ default: m.OnboardingWizard })))
@@ -59,6 +60,7 @@ function App() {
             <Route path="/onboarding" element={<OnboardingWizard />} />
             <Route path="/group/:groupId" element={<GroupDetail />} />
             <Route path="/group/:groupId/settings" element={<GroupSettings />} />
+            <Route path="/group/:groupId/duplicate" element={<DuplicateGroup />} />
             <Route path="/preferences" element={<Preferences />} />
             <Route path="/import" element={<ImportFromUrl />} />
             <Route path="/import/shared" element={<ShareTargetImport />} />

--- a/src/features/groups/DuplicateGroup.tsx
+++ b/src/features/groups/DuplicateGroup.tsx
@@ -13,6 +13,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import type { Group } from '../../domain/entities'
 import { useStore } from '../../store'
 
 const EMOJI_SHORTCUTS = [
@@ -35,90 +36,16 @@ function buildDraftId(): string {
 export function DuplicateGroup() {
   const { groupId } = useParams<{ groupId: string }>()
   const navigate = useNavigate()
-  const { groups, loadGroups, duplicateGroup } = useStore()
+  const { groups, loadGroups } = useStore()
 
   const sourceGroup = useMemo(
     () => groups.find((group) => group.id === groupId),
     [groups, groupId],
   )
 
-  const [name, setName] = useState('')
-  const [description, setDescription] = useState('')
-  const [icon, setIcon] = useState('')
-  const [currency, setCurrency] = useState('EUR')
-  const [members, setMembers] = useState<DraftMember[]>([])
-  const [saving, setSaving] = useState(false)
-  const [error, setError] = useState('')
-
   useEffect(() => {
     loadGroups()
   }, [loadGroups])
-
-  useEffect(() => {
-    if (!sourceGroup) return
-    setName(`${sourceGroup.name} (còpia)`)
-    setDescription(sourceGroup.description ?? '')
-    setIcon(sourceGroup.icon ?? '')
-    setCurrency(sourceGroup.currency)
-    setMembers(
-      sourceGroup.members
-        .filter((member) => !member.deleted)
-        .map((member) => ({
-          id: buildDraftId(),
-          name: member.name,
-          color: member.color,
-        })),
-    )
-  }, [sourceGroup])
-
-  const updateMember = (memberId: string, nextName: string) => {
-    setMembers((current) => current.map((member) => (
-      member.id === memberId ? { ...member, name: nextName } : member
-    )))
-  }
-
-  const removeMember = (memberId: string) => {
-    setMembers((current) => current.filter((member) => member.id !== memberId))
-  }
-
-  const addMember = () => {
-    setMembers((current) => [...current, { id: buildDraftId(), name: '' }])
-  }
-
-  const handleSave = async (e: React.FormEvent) => {
-    e.preventDefault()
-    if (!groupId || !sourceGroup) return
-
-    const cleanedMembers = members
-      .map((member) => ({ name: member.name.trim(), color: member.color }))
-      .filter((member) => member.name.length > 0)
-
-    if (!name.trim()) {
-      setError('Cal un nom per al nou grup.')
-      return
-    }
-
-    if (cleanedMembers.length === 0) {
-      setError('Cal almenys un membre per crear la còpia.')
-      return
-    }
-
-    setSaving(true)
-    setError('')
-    try {
-      const group = await duplicateGroup(groupId, {
-        name: name.trim(),
-        description: description.trim() || undefined,
-        icon: icon.trim() || undefined,
-        currency,
-        members: cleanedMembers,
-      })
-      navigate(`/group/${group.id}`)
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'No s\'ha pogut duplicar el grup.')
-      setSaving(false)
-    }
-  }
 
   if (!sourceGroup) {
     return (
@@ -147,137 +74,209 @@ export function DuplicateGroup() {
         </div>
       </div>
 
-      <form onSubmit={handleSave} className="space-y-6">
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base flex items-center gap-2">
-              <Copy className="h-4 w-4" />
-              Configuració inicial
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-5">
-            <div className="space-y-2">
-              <Label>Icona</Label>
-              <div className="flex items-start gap-4">
-                <div className="flex h-16 w-16 items-center justify-center rounded-full bg-muted text-3xl shrink-0">
-                  {icon || '👥'}
-                </div>
-                <div className="flex-1 space-y-2">
-                  <Input
-                    type="text"
-                    value={icon}
-                    onChange={(e) => setIcon(e.target.value)}
-                    placeholder="Escriu un emoji…"
-                    maxLength={MAX_ICON_LENGTH}
-                  />
-                  <div className="flex flex-wrap gap-1">
-                    {EMOJI_SHORTCUTS.map((emoji) => (
-                      <button
-                        key={emoji}
-                        type="button"
-                        onClick={() => setIcon(emoji)}
-                        className="text-lg hover:bg-muted rounded px-1 py-0.5 transition-colors"
-                        aria-label={emoji}
-                      >
-                        {emoji}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <div className="space-y-1.5">
-              <Label htmlFor="duplicate-group-name">Nom</Label>
-              <Input
-                id="duplicate-group-name"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                placeholder="Nom del nou grup"
-                required
-              />
-            </div>
-
-            <div className="space-y-1.5">
-              <Label htmlFor="duplicate-group-description">
-                Descripció <span className="text-muted-foreground font-normal">(opcional)</span>
-              </Label>
-              <Textarea
-                id="duplicate-group-description"
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                placeholder="Per a qui és aquest grup?"
-                rows={2}
-              />
-            </div>
-
-            <div className="space-y-1.5">
-              <Label htmlFor="duplicate-group-currency">Moneda</Label>
-              <Select value={currency} onValueChange={setCurrency}>
-                <SelectTrigger id="duplicate-group-currency">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="EUR">EUR €</SelectItem>
-                  <SelectItem value="USD">USD $</SelectItem>
-                  <SelectItem value="GBP">GBP £</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base flex items-center gap-2">
-              <Users className="h-4 w-4" />
-              Membres que es copiaran
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            {members.map((member) => (
-              <div key={member.id} className="flex items-center gap-2">
-                <div
-                  className="h-3 w-3 rounded-full shrink-0"
-                  style={{ backgroundColor: member.color ?? '#6366f1' }}
-                  aria-hidden="true"
-                />
-                <Input
-                  value={member.name}
-                  onChange={(e) => updateMember(member.id, e.target.value)}
-                  placeholder="Nom del membre"
-                />
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => removeMember(member.id)}
-                  aria-label="Eliminar membre de la còpia"
-                >
-                  <X className="h-4 w-4" />
-                </Button>
-              </div>
-            ))}
-
-            <Button type="button" variant="outline" onClick={addMember} className="w-full">
-              <Plus className="h-4 w-4 mr-2" />
-              Afegir membre
-            </Button>
-            <p className="text-sm text-muted-foreground">
-              La còpia es crea neta: no s'hi traslladen despeses, pagaments ni historial.
-            </p>
-          </CardContent>
-        </Card>
-
-        {error && (
-          <p className="text-sm text-destructive">{error}</p>
-        )}
-
-        <Button type="submit" className="w-full" disabled={saving}>
-          <Check className="h-4 w-4 mr-2" />
-          {saving ? 'Creant còpia…' : 'Crear grup a partir d\'aquest'}
-        </Button>
-      </form>
+      <DuplicateGroupForm key={sourceGroup.id} sourceGroup={sourceGroup} />
     </div>
+  )
+}
+
+function DuplicateGroupForm({ sourceGroup }: { sourceGroup: Group }) {
+  const navigate = useNavigate()
+  const { duplicateGroup } = useStore()
+  const [name, setName] = useState(() => `${sourceGroup.name} (còpia)`)
+  const [description, setDescription] = useState(() => sourceGroup.description ?? '')
+  const [icon, setIcon] = useState(() => sourceGroup.icon ?? '')
+  const [currency, setCurrency] = useState(() => sourceGroup.currency)
+  const [members, setMembers] = useState<DraftMember[]>(() => (
+    sourceGroup.members
+      .filter((member) => !member.deleted)
+      .map((member) => ({
+        id: buildDraftId(),
+        name: member.name,
+        color: member.color,
+      }))
+  ))
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+
+  const updateMember = (memberId: string, nextName: string) => {
+    setMembers((current) => current.map((member) => (
+      member.id === memberId ? { ...member, name: nextName } : member
+    )))
+  }
+
+  const removeMember = (memberId: string) => {
+    setMembers((current) => current.filter((member) => member.id !== memberId))
+  }
+
+  const addMember = () => {
+    setMembers((current) => [...current, { id: buildDraftId(), name: '' }])
+  }
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault()
+
+    const cleanedMembers = members
+      .map((member) => ({ name: member.name.trim(), color: member.color }))
+      .filter((member) => member.name.length > 0)
+
+    if (!name.trim()) {
+      setError('Cal un nom per al nou grup.')
+      return
+    }
+
+    if (cleanedMembers.length === 0) {
+      setError('Cal almenys un membre per crear la còpia.')
+      return
+    }
+
+    setSaving(true)
+    setError('')
+    try {
+      const group = await duplicateGroup(sourceGroup.id, {
+        name: name.trim(),
+        description: description.trim() || undefined,
+        icon: icon.trim() || undefined,
+        currency,
+        members: cleanedMembers,
+      })
+      navigate(`/group/${group.id}`)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'No s\'ha pogut duplicar el grup.')
+      setSaving(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSave} className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base flex items-center gap-2">
+            <Copy className="h-4 w-4" />
+            Configuració inicial
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-5">
+          <div className="space-y-2">
+            <Label>Icona</Label>
+            <div className="flex items-start gap-4">
+              <div className="flex h-16 w-16 items-center justify-center rounded-full bg-muted text-3xl shrink-0">
+                {icon || '👥'}
+              </div>
+              <div className="flex-1 space-y-2">
+                <Input
+                  type="text"
+                  value={icon}
+                  onChange={(e) => setIcon(e.target.value)}
+                  placeholder="Escriu un emoji…"
+                  maxLength={MAX_ICON_LENGTH}
+                />
+                <div className="flex flex-wrap gap-1">
+                  {EMOJI_SHORTCUTS.map((emoji) => (
+                    <button
+                      key={emoji}
+                      type="button"
+                      onClick={() => setIcon(emoji)}
+                      className="text-lg hover:bg-muted rounded px-1 py-0.5 transition-colors"
+                      aria-label={emoji}
+                    >
+                      {emoji}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="duplicate-group-name">Nom</Label>
+            <Input
+              id="duplicate-group-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Nom del nou grup"
+              required
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="duplicate-group-description">
+              Descripció <span className="text-muted-foreground font-normal">(opcional)</span>
+            </Label>
+            <Textarea
+              id="duplicate-group-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Per a qui és aquest grup?"
+              rows={2}
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="duplicate-group-currency">Moneda</Label>
+            <Select value={currency} onValueChange={setCurrency}>
+              <SelectTrigger id="duplicate-group-currency">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="EUR">EUR €</SelectItem>
+                <SelectItem value="USD">USD $</SelectItem>
+                <SelectItem value="GBP">GBP £</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base flex items-center gap-2">
+            <Users className="h-4 w-4" />
+            Membres que es copiaran
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {members.map((member) => (
+            <div key={member.id} className="flex items-center gap-2">
+              <div
+                className="h-3 w-3 rounded-full shrink-0"
+                style={{ backgroundColor: member.color ?? '#6366f1' }}
+                aria-hidden="true"
+              />
+              <Input
+                value={member.name}
+                onChange={(e) => updateMember(member.id, e.target.value)}
+                placeholder="Nom del membre"
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                onClick={() => removeMember(member.id)}
+                aria-label="Eliminar membre de la còpia"
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+          ))}
+
+          <Button type="button" variant="outline" onClick={addMember} className="w-full">
+            <Plus className="h-4 w-4 mr-2" />
+            Afegir membre
+          </Button>
+          <p className="text-sm text-muted-foreground">
+            La còpia es crea neta: no s'hi traslladen despeses, pagaments ni historial.
+          </p>
+        </CardContent>
+      </Card>
+
+      {error && (
+        <p className="text-sm text-destructive">{error}</p>
+      )}
+
+      <Button type="submit" className="w-full" disabled={saving}>
+        <Check className="h-4 w-4 mr-2" />
+        {saving ? 'Creant còpia…' : 'Crear grup a partir d\'aquest'}
+      </Button>
+    </form>
   )
 }

--- a/src/features/groups/DuplicateGroup.tsx
+++ b/src/features/groups/DuplicateGroup.tsx
@@ -1,0 +1,283 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { ArrowLeft, Check, Copy, Plus, X, Users } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { useStore } from '../../store'
+
+const EMOJI_SHORTCUTS = [
+  '🏖️', '🍕', '✈️', '🏠', '🎉', '🏕️', '🍺', '🎵', '⚽', '💼',
+  '🎒', '🚗', '🎄', '🌍', '🏋️', '🍣', '🎓', '🛒', '🎸', '🏔️',
+]
+
+const MAX_ICON_LENGTH = 4
+
+interface DraftMember {
+  id: string
+  name: string
+  color?: string
+}
+
+function buildDraftId(): string {
+  return crypto.randomUUID()
+}
+
+export function DuplicateGroup() {
+  const { groupId } = useParams<{ groupId: string }>()
+  const navigate = useNavigate()
+  const { groups, loadGroups, duplicateGroup } = useStore()
+
+  const sourceGroup = useMemo(
+    () => groups.find((group) => group.id === groupId),
+    [groups, groupId],
+  )
+
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [icon, setIcon] = useState('')
+  const [currency, setCurrency] = useState('EUR')
+  const [members, setMembers] = useState<DraftMember[]>([])
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    loadGroups()
+  }, [loadGroups])
+
+  useEffect(() => {
+    if (!sourceGroup) return
+    setName(`${sourceGroup.name} (còpia)`)
+    setDescription(sourceGroup.description ?? '')
+    setIcon(sourceGroup.icon ?? '')
+    setCurrency(sourceGroup.currency)
+    setMembers(
+      sourceGroup.members
+        .filter((member) => !member.deleted)
+        .map((member) => ({
+          id: buildDraftId(),
+          name: member.name,
+          color: member.color,
+        })),
+    )
+  }, [sourceGroup])
+
+  const updateMember = (memberId: string, nextName: string) => {
+    setMembers((current) => current.map((member) => (
+      member.id === memberId ? { ...member, name: nextName } : member
+    )))
+  }
+
+  const removeMember = (memberId: string) => {
+    setMembers((current) => current.filter((member) => member.id !== memberId))
+  }
+
+  const addMember = () => {
+    setMembers((current) => [...current, { id: buildDraftId(), name: '' }])
+  }
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!groupId || !sourceGroup) return
+
+    const cleanedMembers = members
+      .map((member) => ({ name: member.name.trim(), color: member.color }))
+      .filter((member) => member.name.length > 0)
+
+    if (!name.trim()) {
+      setError('Cal un nom per al nou grup.')
+      return
+    }
+
+    if (cleanedMembers.length === 0) {
+      setError('Cal almenys un membre per crear la còpia.')
+      return
+    }
+
+    setSaving(true)
+    setError('')
+    try {
+      const group = await duplicateGroup(groupId, {
+        name: name.trim(),
+        description: description.trim() || undefined,
+        icon: icon.trim() || undefined,
+        currency,
+        members: cleanedMembers,
+      })
+      navigate(`/group/${group.id}`)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'No s\'ha pogut duplicar el grup.')
+      setSaving(false)
+    }
+  }
+
+  if (!sourceGroup) {
+    return (
+      <div className="max-w-2xl mx-auto p-4">
+        <p className="text-muted-foreground">Carregant...</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto p-4">
+      <div className="flex items-center gap-3 mb-6">
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={() => navigate(`/group/${groupId}/settings`)}
+          aria-label="Tornar"
+        >
+          <ArrowLeft className="h-5 w-5" />
+        </Button>
+        <div>
+          <h1 className="text-2xl font-bold">Duplicar grup</h1>
+          <p className="text-sm text-muted-foreground">
+            Parteix de &quot;{sourceGroup.name}&quot; amb membres i configuració, però sense activitat econòmica prèvia.
+          </p>
+        </div>
+      </div>
+
+      <form onSubmit={handleSave} className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base flex items-center gap-2">
+              <Copy className="h-4 w-4" />
+              Configuració inicial
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-5">
+            <div className="space-y-2">
+              <Label>Icona</Label>
+              <div className="flex items-start gap-4">
+                <div className="flex h-16 w-16 items-center justify-center rounded-full bg-muted text-3xl shrink-0">
+                  {icon || '👥'}
+                </div>
+                <div className="flex-1 space-y-2">
+                  <Input
+                    type="text"
+                    value={icon}
+                    onChange={(e) => setIcon(e.target.value)}
+                    placeholder="Escriu un emoji…"
+                    maxLength={MAX_ICON_LENGTH}
+                  />
+                  <div className="flex flex-wrap gap-1">
+                    {EMOJI_SHORTCUTS.map((emoji) => (
+                      <button
+                        key={emoji}
+                        type="button"
+                        onClick={() => setIcon(emoji)}
+                        className="text-lg hover:bg-muted rounded px-1 py-0.5 transition-colors"
+                        aria-label={emoji}
+                      >
+                        {emoji}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="duplicate-group-name">Nom</Label>
+              <Input
+                id="duplicate-group-name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="Nom del nou grup"
+                required
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="duplicate-group-description">
+                Descripció <span className="text-muted-foreground font-normal">(opcional)</span>
+              </Label>
+              <Textarea
+                id="duplicate-group-description"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Per a qui és aquest grup?"
+                rows={2}
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="duplicate-group-currency">Moneda</Label>
+              <Select value={currency} onValueChange={setCurrency}>
+                <SelectTrigger id="duplicate-group-currency">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="EUR">EUR €</SelectItem>
+                  <SelectItem value="USD">USD $</SelectItem>
+                  <SelectItem value="GBP">GBP £</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base flex items-center gap-2">
+              <Users className="h-4 w-4" />
+              Membres que es copiaran
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {members.map((member) => (
+              <div key={member.id} className="flex items-center gap-2">
+                <div
+                  className="h-3 w-3 rounded-full shrink-0"
+                  style={{ backgroundColor: member.color ?? '#6366f1' }}
+                  aria-hidden="true"
+                />
+                <Input
+                  value={member.name}
+                  onChange={(e) => updateMember(member.id, e.target.value)}
+                  placeholder="Nom del membre"
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => removeMember(member.id)}
+                  aria-label="Eliminar membre de la còpia"
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              </div>
+            ))}
+
+            <Button type="button" variant="outline" onClick={addMember} className="w-full">
+              <Plus className="h-4 w-4 mr-2" />
+              Afegir membre
+            </Button>
+            <p className="text-sm text-muted-foreground">
+              La còpia es crea neta: no s'hi traslladen despeses, pagaments ni historial.
+            </p>
+          </CardContent>
+        </Card>
+
+        {error && (
+          <p className="text-sm text-destructive">{error}</p>
+        )}
+
+        <Button type="submit" className="w-full" disabled={saving}>
+          <Check className="h-4 w-4 mr-2" />
+          {saving ? 'Creant còpia…' : 'Crear grup a partir d\'aquest'}
+        </Button>
+      </form>
+    </div>
+  )
+}

--- a/src/features/groups/GroupList.tsx
+++ b/src/features/groups/GroupList.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { useStore } from '../../store'
 import { useNavigate } from 'react-router-dom'
-import { Plus, Trash2, Users, Upload, Archive, ChevronDown, Settings, MoreHorizontal } from 'lucide-react'
+import { Plus, Trash2, Users, Upload, Archive, ChevronDown, Settings, MoreHorizontal, Copy } from 'lucide-react'
 import { ONBOARDING_COMPLETED_KEY } from './OnboardingWizard'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
@@ -180,6 +180,19 @@ export function GroupList() {
               >
                 <Settings className="h-4 w-4" />
                 Configuració
+              </button>
+
+              <button
+                type="button"
+                role="menuitem"
+                onClick={() => {
+                  setOpenGroupMenuId(null)
+                  navigate(`/group/${group.id}/duplicate`)
+                }}
+                className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-foreground hover:bg-muted"
+              >
+                <Copy className="h-4 w-4" />
+                Duplicar grup
               </button>
 
               <AlertDialog>

--- a/src/features/groups/GroupSettings.tsx
+++ b/src/features/groups/GroupSettings.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useEffect, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { ArrowLeft, Trash2, Download, Share2, Archive, ArchiveRestore } from 'lucide-react'
+import { ArrowLeft, Trash2, Download, Share2, Archive, ArchiveRestore, Copy } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
@@ -208,6 +208,28 @@ function GroupSettingsForm({ group, groupId }: GroupSettingsFormProps) {
 
       <Card>
         <CardHeader>
+          <CardTitle className="text-base">Crear un grup nou a partir d'aquest</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <p className="text-sm text-muted-foreground">
+            Duplica membres i configuració del grup per començar-ne un de nou sense arrossegar despeses ni pagaments anteriors.
+          </p>
+          <Button
+            variant="outline"
+            className="w-full"
+            type="button"
+            onClick={() => navigate(`/group/${groupId}/duplicate`)}
+          >
+            <Copy className="h-4 w-4 mr-2" />
+            Duplicar grup
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Separator className="my-8" />
+
+      <Card>
+        <CardHeader>
           <CardTitle className="text-base">Guardar una còpia del grup</CardTitle>
         </CardHeader>
         <CardContent className="space-y-2">
@@ -365,4 +387,3 @@ export function GroupSettings() {
     </div>
   )
 }
-

--- a/src/sdk.test.ts
+++ b/src/sdk.test.ts
@@ -80,6 +80,51 @@ describe('reparteix SDK', () => {
         reparteix.updateGroup('non-existent', { name: 'Test' }),
       ).rejects.toThrow()
     })
+
+    it('duplicates a group as a clean starting point', async () => {
+      const source = await reparteix.createGroup('Pis compartit')
+      await reparteix.updateGroup(source.id, {
+        description: 'Curs 2026',
+        icon: '🏠',
+        currency: 'USD',
+      })
+      const anna = await reparteix.addMember(source.id, 'Anna')
+      const bernat = await reparteix.addMember(source.id, 'Bernat')
+      await reparteix.addExpense({
+        groupId: source.id,
+        description: 'Internet',
+        amount: 40,
+        payerId: anna.id,
+        splitAmong: [anna.id, bernat.id],
+        date: '2026-04-01',
+      })
+
+      const duplicate = await reparteix.duplicateGroup(source.id, {
+        name: 'Pis compartit 2027',
+        members: [
+          { name: 'Anna' },
+          { name: 'Bernat' },
+          { name: 'Clara' },
+        ],
+      })
+
+      expect(duplicate.id).not.toBe(source.id)
+      expect(duplicate.name).toBe('Pis compartit 2027')
+      expect(duplicate.description).toBe('Curs 2026')
+      expect(duplicate.icon).toBe('🏠')
+      expect(duplicate.currency).toBe('USD')
+      expect(duplicate.members.map((member) => member.name)).toEqual(['Anna', 'Bernat', 'Clara'])
+
+      const duplicateExpenses = await reparteix.listExpenses(duplicate.id)
+      const duplicatePayments = await reparteix.listPayments(duplicate.id)
+      expect(duplicateExpenses).toEqual([])
+      expect(duplicatePayments).toEqual([])
+
+      const duplicateActivity = await reparteix.listActivity(duplicate.id)
+      expect(duplicateActivity).toHaveLength(4)
+      expect(duplicateActivity.filter((entry) => entry.action === 'group.created')).toHaveLength(1)
+      expect(duplicateActivity.filter((entry) => entry.action === 'member.added')).toHaveLength(3)
+    })
   })
 
   // ─── Archive / Unarchive ─────────────────────────────────────────

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -141,6 +141,73 @@ export const reparteix = {
     return group
   },
 
+  /** Duplicate an existing group as a fresh starting point without expenses or payments. */
+  async duplicateGroup(
+    sourceGroupId: string,
+    template?: {
+      name?: string
+      description?: string
+      icon?: string
+      currency?: string
+      members?: Array<{ name: string; color?: string }>
+    },
+  ): Promise<Group> {
+    const sourceGroup = await db.groups.get(sourceGroupId)
+    if (!sourceGroup || sourceGroup.deleted) throw new Error(`Group not found: ${sourceGroupId}`)
+
+    const timestamp = now()
+    const sourceMembers = sourceGroup.members.filter((member) => !member.deleted)
+    const memberTemplates = template?.members ?? sourceMembers.map((member) => ({
+      name: member.name,
+      color: member.color,
+    }))
+
+    const members: Member[] = memberTemplates
+      .map((member, index) => ({
+        id: generateId(),
+        name: member.name.trim(),
+        color: member.color ?? getMemberColor(index),
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        deleted: false,
+      }))
+      .filter((member) => member.name.length > 0)
+
+    const group: Group = {
+      id: generateId(),
+      name: template?.name?.trim() || `${sourceGroup.name} (còpia)`,
+      description: template?.description?.trim() || sourceGroup.description,
+      icon: template?.icon?.trim() || sourceGroup.icon,
+      currency: template?.currency ?? sourceGroup.currency,
+      members,
+      archived: false,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      deleted: false,
+    }
+
+    await db.groups.add(group)
+    await appendActivity({
+      groupId: group.id,
+      entityType: 'group',
+      entityId: group.id,
+      action: 'group.created',
+      after: sanitizeActivitySnapshot(group),
+      meta: { sourceGroupId },
+    })
+    for (const member of members) {
+      await appendActivity({
+        groupId: group.id,
+        entityType: 'member',
+        entityId: member.id,
+        action: 'member.added',
+        after: sanitizeActivitySnapshot(member),
+        meta: { memberName: member.name, sourceGroupId },
+      })
+    }
+    return group
+  },
+
   /** Update group metadata (name, description, icon, currency, syncPassphrase). Throws if the group is archived. */
   async updateGroup(
     id: string,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -13,6 +13,7 @@ interface AppState {
   loadGroups: () => Promise<void>
   loadGroupData: (groupId: string) => Promise<void>
   addGroup: (name: string) => Promise<Group>
+  duplicateGroup: (sourceGroupId: string, template?: { name?: string; description?: string; icon?: string; currency?: string; members?: Array<{ name: string; color?: string }> }) => Promise<Group>
   updateGroup: (id: string, updates: { name?: string; description?: string; icon?: string; currency?: string; syncPassphrase?: string }) => Promise<void>
   deleteGroup: (id: string) => Promise<void>
   archiveGroup: (id: string) => Promise<void>
@@ -58,6 +59,12 @@ export const useStore = create<AppState>((set, get) => ({
 
   addGroup: async (name: string) => {
     const group = await reparteix.createGroup(name)
+    await get().loadGroups()
+    return group
+  },
+
+  duplicateGroup: async (sourceGroupId: string, template) => {
+    const group = await reparteix.duplicateGroup(sourceGroupId, template)
     await get().loadGroups()
     return group
   },

--- a/src/store/store.test.ts
+++ b/src/store/store.test.ts
@@ -110,6 +110,30 @@ describe('groups', () => {
     expect(updated.currency).toBe('USD')
   })
 
+  it('duplicateGroup crea un grup nou editable a partir d’un existent', async () => {
+    const { addGroup, addMember, updateGroup, duplicateGroup } = useStore.getState()
+    const source = await addGroup('Casa')
+    await updateGroup(source.id, { description: 'Pis compartit', icon: '🏠', currency: 'GBP' })
+    await addMember(source.id, 'Anna')
+    await addMember(source.id, 'Bernat')
+
+    const duplicate = await duplicateGroup(source.id, {
+      name: 'Casa estiu',
+      description: 'Vacances',
+      icon: '🌴',
+      currency: 'EUR',
+      members: [{ name: 'Anna' }, { name: 'Clara' }],
+    })
+
+    const created = useStore.getState().groups.find((group) => group.id === duplicate.id)
+    expect(created).toBeTruthy()
+    expect(created?.name).toBe('Casa estiu')
+    expect(created?.description).toBe('Vacances')
+    expect(created?.icon).toBe('🌴')
+    expect(created?.currency).toBe('EUR')
+    expect(created?.members.filter((member) => !member.deleted).map((member) => member.name)).toEqual(['Anna', 'Clara'])
+  })
+
   it("deleteGroup elimina el grup de l'estat", async () => {
     const { addGroup, deleteGroup } = useStore.getState()
     const group = await addGroup('Per esborrar')


### PR DESCRIPTION
Closes #153

## Resum
- afegeix el flux `Duplicar grup` per crear un grup nou a partir d'un existent
- permet revisar i editar nom, descripció, icona, moneda i membres abans de guardar
- la còpia neix neta, sense despeses, pagaments ni historial econòmic
- exposa l'acció des del menú de cada grup i des de configuració

## Validació
- `npm test -- --run src/sdk.test.ts src/store/store.test.ts`
- `npm run build`
