### PR TITLE
fix: restore group deletion from settings

### DIFF
--- a/src/features/groups/GroupList.tsx
+++ b/src/features/groups/GroupList.tsx
@@ -16,7 +16,6 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-  AlertDialogTrigger,
 } from '@/components/ui/alert-dialog'
 import { getLocalDeviceIdentity, needsDeviceLabelSetup } from '@/lib/device-identity'
 
@@ -29,6 +28,7 @@ export function GroupList() {
   const [importError, setImportError] = useState('')
   const [showArchived, setShowArchived] = useState(false)
   const [openGroupMenuId, setOpenGroupMenuId] = useState<string | null>(null)
+  const [deleteGroupId, setDeleteGroupId] = useState<string | null>(null)
   const [onboardingCompleted] = useState(() => {
     try {
       return localStorage.getItem(ONBOARDING_COMPLETED_KEY) === 'true'
@@ -95,6 +95,7 @@ export function GroupList() {
   const activeGroups = groups.filter((g) => !g.archived)
   const archivedGroups = groups.filter((g) => g.archived)
   const hasGroups = groups.length > 0
+  const groupPendingDeletion = deleteGroupId ? groups.find((group) => group.id === deleteGroupId) : null
 
   const renderGroupCard = (group: (typeof groups)[number]) => {
     const total = groupTotals[group.id] ?? 0
@@ -187,36 +188,18 @@ export function GroupList() {
                 Configuració
               </button>
 
-              <AlertDialog>
-                <AlertDialogTrigger asChild>
-                  <button
-                    type="button"
-                    role="menuitem"
-                    onClick={() => setOpenGroupMenuId(null)}
-                    className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-destructive hover:bg-muted"
-                  >
-                    <Trash2 className="h-4 w-4" />
-                    Eliminar
-                  </button>
-                </AlertDialogTrigger>
-                <AlertDialogContent>
-                  <AlertDialogHeader>
-                    <AlertDialogTitle>Eliminar grup</AlertDialogTitle>
-                    <AlertDialogDescription>
-                      Estàs segur que vols eliminar el grup &quot;{group.name}&quot;? Aquesta acció no es pot desfer.
-                    </AlertDialogDescription>
-                  </AlertDialogHeader>
-                  <AlertDialogFooter>
-                    <AlertDialogCancel>Cancel·lar</AlertDialogCancel>
-                    <AlertDialogAction
-                      onClick={() => deleteGroup(group.id)}
-                      className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                    >
-                      Eliminar
-                    </AlertDialogAction>
-                  </AlertDialogFooter>
-                </AlertDialogContent>
-              </AlertDialog>
+              <button
+                type="button"
+                role="menuitem"
+                onClick={() => {
+                  setOpenGroupMenuId(null)
+                  setDeleteGroupId(group.id)
+                }}
+                className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-destructive hover:bg-muted"
+              >
+                <Trash2 className="h-4 w-4" />
+                Eliminar
+              </button>
             </div>
           )}
         </div>
@@ -227,6 +210,32 @@ export function GroupList() {
 
   return (
     <div className="min-h-screen bg-muted/50">
+      <AlertDialog open={deleteGroupId !== null} onOpenChange={(open) => !open && setDeleteGroupId(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Eliminar grup</AlertDialogTitle>
+            <AlertDialogDescription>
+              {groupPendingDeletion
+                ? `Estàs segur que vols eliminar el grup "${groupPendingDeletion.name}"? Aquesta acció no es pot desfer.`
+                : 'Estàs segur que vols eliminar aquest grup? Aquesta acció no es pot desfer.'}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel·lar</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={async () => {
+                if (!deleteGroupId) return
+                await deleteGroup(deleteGroupId)
+                setDeleteGroupId(null)
+              }}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Eliminar
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
       {/* Hero / Header */}
       <div className="bg-gradient-to-br from-indigo-600 to-indigo-800 dark:from-indigo-800 dark:to-indigo-950 text-white px-4 pt-10 pb-12">
         <div className="max-w-2xl mx-auto">

--- a/src/features/groups/GroupSettings.tsx
+++ b/src/features/groups/GroupSettings.tsx
@@ -6,6 +6,17 @@ import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { Label } from '@/components/ui/label'
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog'
+import {
   Select,
   SelectContent,
   SelectItem,
@@ -64,7 +75,6 @@ function GroupSettingsForm({ group, groupId }: GroupSettingsFormProps) {
   }
 
   const handleDelete = async () => {
-    if (!window.confirm('Segur que vols eliminar el grup? Aquesta acció no es pot desfer.')) return
     await deleteGroup(groupId)
     navigate('/')
   }
@@ -317,15 +327,35 @@ function GroupSettingsForm({ group, groupId }: GroupSettingsFormProps) {
           <CardTitle className="text-destructive text-base">Zona de perill</CardTitle>
         </CardHeader>
         <CardContent>
-          <Button
-            variant="destructive"
-            className="w-full"
-            type="button"
-            onClick={handleDelete}
-          >
-            <Trash2 className="h-4 w-4 mr-2" />
-            Eliminar grup
-          </Button>
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button
+                variant="destructive"
+                className="w-full"
+                type="button"
+              >
+                <Trash2 className="h-4 w-4 mr-2" />
+                Eliminar grup
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Eliminar grup</AlertDialogTitle>
+                <AlertDialogDescription>
+                  Estàs segur que vols eliminar el grup &quot;{group.name}&quot;? Aquesta acció no es pot desfer.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel·lar</AlertDialogCancel>
+                <AlertDialogAction
+                  onClick={handleDelete}
+                  className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                >
+                  Eliminar
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
         </CardContent>
       </Card>
     </>
@@ -365,4 +395,3 @@ export function GroupSettings() {
     </div>
   )
 }
-

--- a/src/features/groups/GroupSettings.tsx
+++ b/src/features/groups/GroupSettings.tsx
@@ -6,17 +6,6 @@ import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { Label } from '@/components/ui/label'
 import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from '@/components/ui/alert-dialog'
-import {
   Select,
   SelectContent,
   SelectItem,
@@ -59,6 +48,8 @@ function GroupSettingsForm({ group, groupId }: GroupSettingsFormProps) {
   const [currency, setCurrency] = useState(group.currency)
   const [exportStatus, setExportStatus] = useState<'idle' | 'ok' | 'error'>('idle')
   const [shareStatus, setShareStatus] = useState<'idle' | 'shared' | 'copied' | 'error'>('idle')
+  const [isDeleteConfirming, setIsDeleteConfirming] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
 
   const isArchived = group.archived
 
@@ -75,8 +66,13 @@ function GroupSettingsForm({ group, groupId }: GroupSettingsFormProps) {
   }
 
   const handleDelete = async () => {
-    await deleteGroup(groupId)
-    navigate('/')
+    setIsDeleting(true)
+    try {
+      await deleteGroup(groupId)
+      navigate('/')
+    } finally {
+      setIsDeleting(false)
+    }
   }
 
   const handleArchive = async () => {
@@ -326,36 +322,45 @@ function GroupSettingsForm({ group, groupId }: GroupSettingsFormProps) {
         <CardHeader>
           <CardTitle className="text-destructive text-base">Zona de perill</CardTitle>
         </CardHeader>
-        <CardContent>
-          <AlertDialog>
-            <AlertDialogTrigger asChild>
-              <Button
-                variant="destructive"
-                className="w-full"
-                type="button"
-              >
-                <Trash2 className="h-4 w-4 mr-2" />
-                Eliminar grup
-              </Button>
-            </AlertDialogTrigger>
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>Eliminar grup</AlertDialogTitle>
-                <AlertDialogDescription>
-                  Estàs segur que vols eliminar el grup &quot;{group.name}&quot;? Aquesta acció no es pot desfer.
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel>Cancel·lar</AlertDialogCancel>
-                <AlertDialogAction
+        <CardContent className="space-y-3">
+          {isDeleteConfirming ? (
+            <>
+              <p className="text-sm text-muted-foreground">
+                Estàs a punt d'eliminar el grup &quot;{group.name}&quot;. Aquesta acció no es pot desfer.
+              </p>
+              <div className="flex gap-2">
+                <Button
+                  variant="destructive"
+                  className="flex-1"
+                  type="button"
                   onClick={handleDelete}
-                  className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                  disabled={isDeleting}
                 >
-                  Eliminar
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
+                  <Trash2 className="h-4 w-4 mr-2" />
+                  {isDeleting ? 'Eliminant…' : 'Confirmar eliminació'}
+                </Button>
+                <Button
+                  variant="outline"
+                  className="flex-1"
+                  type="button"
+                  onClick={() => setIsDeleteConfirming(false)}
+                  disabled={isDeleting}
+                >
+                  Cancel·lar
+                </Button>
+              </div>
+            </>
+          ) : (
+            <Button
+              variant="destructive"
+              className="w-full"
+              type="button"
+              onClick={() => setIsDeleteConfirming(true)}
+            >
+              <Trash2 className="h-4 w-4 mr-2" />
+              Eliminar grup
+            </Button>
+          )}
         </CardContent>
       </Card>
     </>


### PR DESCRIPTION
Closes #174

## Resum
- substitueix `window.confirm` al botó d'eliminar grup per un `AlertDialog`
- alinea la confirmació d'eliminació amb la resta d'accions destructives de la UI
- evita el cas on el botó no responia correctament en aquest flux de configuració

## Validació
- `npm run lint`
- `npm run build`
