### PR TITLE
Localitzar els formats numèrics

### DIFF
--- a/src/features/balances/BalanceView.tsx
+++ b/src/features/balances/BalanceView.tsx
@@ -11,13 +11,8 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Separator } from '@/components/ui/separator'
+import { formatMoney } from '@/lib/number-format'
 import { shareText } from '@/lib/web-share'
-
-const CURRENCY_SYMBOLS: Record<string, string> = {
-  EUR: '€',
-  USD: '$',
-  GBP: '£',
-}
 
 interface BalanceViewProps {
   group: Group
@@ -30,7 +25,6 @@ export function BalanceView({ group }: BalanceViewProps) {
 
   const activeMembers = group.members.filter((m) => !m.deleted)
   const memberIds = activeMembers.map((m) => m.id)
-  const symbol = CURRENCY_SYMBOLS[group.currency] ?? group.currency
 
   const balances = calculateBalances(memberIds, expenses, payments)
   const netting = calculateNetting(balances)
@@ -70,7 +64,7 @@ export function BalanceView({ group }: BalanceViewProps) {
   const buildShareMessage = (fromId: string, toId: string, amount: number) => {
     const debtor = getMemberName(fromId)
     const creditor = getMemberName(toId)
-    return `Hola ${debtor}! Et toca pagar ${amount.toFixed(2)} ${symbol} a ${creditor} del grup "${group.name}" a Reparteix.`
+    return `Hola ${debtor}! Et toca pagar ${formatMoney(amount, group.currency)} a ${creditor} del grup "${group.name}" a Reparteix.`
   }
 
   const buildSettlementSummaryMessage = () => {
@@ -81,7 +75,7 @@ export function BalanceView({ group }: BalanceViewProps) {
     const lines = netting.minimized.map((settlement) => {
       const debtor = getMemberName(settlement.fromId)
       const creditor = getMemberName(settlement.toId)
-      return `• ${debtor} ha de pagar ${settlement.amount.toFixed(2)} ${symbol} a ${creditor}`
+      return `• ${debtor} ha de pagar ${formatMoney(settlement.amount, group.currency)} a ${creditor}`
     })
 
     return [
@@ -89,7 +83,7 @@ export function BalanceView({ group }: BalanceViewProps) {
       '',
       ...lines,
       '',
-      `Total a liquidar: ${totalToSettle.toFixed(2)} ${symbol}`,
+      `Total a liquidar: ${formatMoney(totalToSettle, group.currency)}`,
     ].join('\n')
   }
 
@@ -119,7 +113,7 @@ export function BalanceView({ group }: BalanceViewProps) {
             Total despeses
           </CardDescription>
           <CardTitle className="text-2xl text-indigo-800 dark:text-indigo-200">
-            {totalExpenses.toFixed(2)} {symbol}
+            {formatMoney(totalExpenses, group.currency)}
           </CardTitle>
         </CardHeader>
       </Card>
@@ -152,7 +146,7 @@ export function BalanceView({ group }: BalanceViewProps) {
                     )}
                   >
                     {balance.total > 0 ? '+' : ''}
-                    {balance.total.toFixed(2)} {symbol}
+                    {formatMoney(balance.total, group.currency)}
                   </span>
                 </CardContent>
               </Card>
@@ -201,7 +195,7 @@ export function BalanceView({ group }: BalanceViewProps) {
                 </div>
                 <div className="rounded-xl bg-muted/40 px-3 py-3">
                   <p className="text-[11px] uppercase tracking-wide text-muted-foreground">Total</p>
-                  <p className="mt-1 text-xl font-semibold">{totalToSettle.toFixed(2)} {symbol}</p>
+                  <p className="mt-1 text-xl font-semibold">{formatMoney(totalToSettle, group.currency)}</p>
                 </div>
               </div>
 
@@ -243,12 +237,12 @@ export function BalanceView({ group }: BalanceViewProps) {
                       <span className="font-semibold">{getMemberName(s.toId)}</span>
                     </div>
                     <p className="text-sm text-muted-foreground">
-                      {getMemberName(s.fromId)} hauria de pagar <span className="font-medium text-foreground">{s.amount.toFixed(2)} {symbol}</span> a {getMemberName(s.toId)}.
+                      {getMemberName(s.fromId)} hauria de pagar <span className="font-medium text-foreground">{formatMoney(s.amount, group.currency)}</span> a {getMemberName(s.toId)}.
                     </p>
                   </div>
 
                   <Badge variant="outline" className="w-fit border-amber-300 dark:border-amber-700 text-amber-700 dark:text-amber-300 font-semibold text-sm px-3 py-1">
-                    {s.amount.toFixed(2)} {symbol}
+                    {formatMoney(s.amount, group.currency)}
                   </Badge>
                 </div>
 

--- a/src/features/expenses/ExpenseList.tsx
+++ b/src/features/expenses/ExpenseList.tsx
@@ -29,12 +29,7 @@ import {
 import { Badge } from '@/components/ui/badge'
 import { reparteix } from '@/sdk'
 import { ItemActivityDialog } from '@/features/groups/ItemActivityDialog'
-
-const CURRENCY_SYMBOLS: Record<string, string> = {
-  EUR: '€',
-  USD: '$',
-  GBP: '£',
-}
+import { formatDecimalInput, formatMoney, formatPercent, parseLocaleNumber } from '@/lib/number-format'
 
 const MAX_RECEIPT_FILE_SIZE_MB = 12
 const MAX_RECEIPT_DIMENSION = 1600
@@ -188,7 +183,6 @@ export function ExpenseList({ group }: ExpenseListProps) {
   }, [group.id, expenses])
 
   const activeMembers = group.members.filter((m) => !m.deleted)
-  const symbol = CURRENCY_SYMBOLS[group.currency] ?? group.currency
 
   const memberIds = activeMembers.map((m) => m.id)
   const balances = calculateBalances(memberIds, expenses, payments)
@@ -225,13 +219,13 @@ export function ExpenseList({ group }: ExpenseListProps) {
     splitProportions:
       splitType === 'proportional'
         ? Object.fromEntries(
-            splitAmong.map((id) => [id, parseFloat(proportions[id] ?? '1') || 1]),
+            splitAmong.map((id) => [id, parseLocaleNumber(proportions[id] ?? '1') || 1]),
           )
         : undefined,
     splitFixedAmounts:
       splitType === 'fixed'
         ? Object.fromEntries(
-            splitAmong.map((id) => [id, parseFloat(fixedAmounts[id] ?? '0') || 0]),
+            splitAmong.map((id) => [id, parseLocaleNumber(fixedAmounts[id] ?? '0') || 0]),
           )
         : undefined,
   })
@@ -245,7 +239,7 @@ export function ExpenseList({ group }: ExpenseListProps) {
   const fillExpenseForm = (expense: Expense, options?: { duplicate?: boolean }) => {
     setEditingExpenseId(options?.duplicate ? null : expense.id)
     setDescription(expense.description)
-    setAmount(expense.amount.toString())
+    setAmount(formatDecimalInput(expense.amount))
     setPayerId(expense.payerId)
     setSplitAmong(expense.splitAmong)
     setSplitType(expense.splitType ?? 'equal')
@@ -256,7 +250,7 @@ export function ExpenseList({ group }: ExpenseListProps) {
     )
     setFixedAmounts(
       Object.fromEntries(
-        expense.splitAmong.map((id) => [id, String(expense.splitFixedAmounts?.[id] ?? '')]),
+        expense.splitAmong.map((id) => [id, formatDecimalInput(expense.splitFixedAmounts?.[id] ?? Number.NaN)]),
       ),
     )
     setExpenseDate(options?.duplicate ? getTodayLocalDate() : expense.date)
@@ -279,7 +273,7 @@ export function ExpenseList({ group }: ExpenseListProps) {
     if (!description.trim() || !amount || !payerId || splitAmong.length === 0) return
     if (validationError) return
 
-    const numAmount = parseFloat(amount)
+    const numAmount = parseLocaleNumber(amount)
     const splitFields = buildCurrentSplitFields()
     const baseExpense = {
       groupId: group.id,
@@ -372,19 +366,19 @@ export function ExpenseList({ group }: ExpenseListProps) {
 
   let validationError: string | null = null
   if (splitType === 'fixed' && splitAmong.length > 0 && amount) {
-    const total = parseFloat(amount) || 0
+    const total = parseLocaleNumber(amount) || 0
     const sum = splitAmong.reduce(
-      (s, id) => s + (parseFloat(fixedAmounts[id] ?? '0') || 0),
+      (s, id) => s + (parseLocaleNumber(fixedAmounts[id] ?? '0') || 0),
       0,
     )
     if (sum > total + 0.01) {
-      validationError = `Els imports fixos (${sum.toFixed(2)} ${symbol}) superen el total (${total.toFixed(2)} ${symbol}).`
+      validationError = `Els imports fixos (${formatMoney(sum, group.currency)}) superen el total (${formatMoney(total, group.currency)}).`
     } else if (Math.abs(sum - total) > 0.01) {
-      validationError = `Els imports fixos han de sumar el total (${total.toFixed(2)} ${symbol}). Ara sumen ${sum.toFixed(2)} ${symbol}.`
+      validationError = `Els imports fixos han de sumar el total (${formatMoney(total, group.currency)}). Ara sumen ${formatMoney(sum, group.currency)}.`
     }
   }
 
-  const numAmountPreview = parseFloat(amount)
+  const numAmountPreview = parseLocaleNumber(amount)
   const previewShares: Record<string, number> | null =
     numAmountPreview > 0 && splitAmong.length > 0
       ? computeExpenseShares({
@@ -414,8 +408,8 @@ export function ExpenseList({ group }: ExpenseListProps) {
         expense.splitAmong
           .map((id) => {
             const w = expense.splitProportions![id] ?? 1
-            const pct = total > 0 ? ((w / total) * 100).toFixed(0) : '0'
-            return `${getMemberName(id)} (${pct}%)`
+            const pct = total > 0 ? formatPercent(w / total, 0) : formatPercent(0, 0)
+            return `${getMemberName(id)} (${pct})`
           })
           .join(', ')
       )
@@ -424,7 +418,7 @@ export function ExpenseList({ group }: ExpenseListProps) {
       return (
         'Imports fixos: ' +
         expense.splitAmong
-          .map((id) => `${getMemberName(id)} (${(expense.splitFixedAmounts![id] ?? 0).toFixed(2)} ${symbol})`)
+          .map((id) => `${getMemberName(id)} (${formatMoney(expense.splitFixedAmounts![id] ?? 0, group.currency)})`)
           .join(', ')
       )
     }
@@ -544,7 +538,8 @@ export function ExpenseList({ group }: ExpenseListProps) {
                   <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_180px]">
                     <div className="flex gap-2">
                       <Input
-                        type="number"
+                        type="text"
+                        inputMode="decimal"
                         value={amount}
                         onChange={(e) => setAmount(e.target.value)}
                         placeholder="Import"
@@ -554,7 +549,7 @@ export function ExpenseList({ group }: ExpenseListProps) {
                         required
                       />
                       <span className="flex items-center text-muted-foreground">
-                        {symbol}
+                        {group.currency}
                       </span>
                     </div>
                     <div className="space-y-1">
@@ -636,7 +631,7 @@ export function ExpenseList({ group }: ExpenseListProps) {
                   </div>
                   {splitType === 'proportional' && splitAmong.length > 0 && (() => {
                     const totalWeight = splitAmong.reduce(
-                      (s, id) => s + (parseFloat(proportions[id] ?? '1') || 1),
+                      (s, id) => s + (parseLocaleNumber(proportions[id] ?? '1') || 1),
                       0,
                     )
                     return (
@@ -645,13 +640,14 @@ export function ExpenseList({ group }: ExpenseListProps) {
                           Proporcions (parts relatives)
                         </Label>
                         {splitAmong.map((id) => {
-                          const w = parseFloat(proportions[id] ?? '1') || 1
-                          const pct = totalWeight > 0 ? ((w / totalWeight) * 100).toFixed(1) : '0.0'
+                          const w = parseLocaleNumber(proportions[id] ?? '1') || 1
+                          const pct = totalWeight > 0 ? formatPercent(w / totalWeight, 1) : formatPercent(0, 1)
                           return (
                             <div key={id} className="flex items-center gap-2">
                               <span className="text-sm w-24 truncate">{getMemberName(id)}</span>
                               <Input
-                                type="number"
+                                type="text"
+                                inputMode="decimal"
                                 min="0.01"
                                 step="0.01"
                                 value={proportions[id] ?? '1'}
@@ -664,7 +660,7 @@ export function ExpenseList({ group }: ExpenseListProps) {
                                 className="w-24"
                               />
                               <span className="text-xs text-muted-foreground w-12 text-right tabular-nums">
-                                {pct}%
+                                {pct}
                               </span>
                             </div>
                           )
@@ -676,26 +672,27 @@ export function ExpenseList({ group }: ExpenseListProps) {
                     <div className="space-y-2">
                       <div className="flex items-center justify-between">
                         <Label className="text-sm text-muted-foreground">
-                          Imports fixos ({symbol})
+                          Imports fixos ({group.currency})
                         </Label>
                         <span className={cn(
                           'text-xs font-medium',
-                          amount && Math.abs(splitAmong.reduce((s, id) => s + (parseFloat(fixedAmounts[id] ?? '0') || 0), 0) - (parseFloat(amount) || 0)) <= 0.01
+                          amount && Math.abs(splitAmong.reduce((s, id) => s + (parseLocaleNumber(fixedAmounts[id] ?? '0') || 0), 0) - (parseLocaleNumber(amount) || 0)) <= 0.01
                             ? 'text-success'
                             : 'text-destructive',
                         )}>
-                          {splitAmong.reduce((s, id) => s + (parseFloat(fixedAmounts[id] ?? '0') || 0), 0).toFixed(2)} / {(parseFloat(amount) || 0).toFixed(2)} {symbol}
+                          {formatMoney(splitAmong.reduce((s, id) => s + (parseLocaleNumber(fixedAmounts[id] ?? '0') || 0), 0), group.currency)} / {formatMoney(parseLocaleNumber(amount) || 0, group.currency)}
                         </span>
                       </div>
                       {splitAmong.map((id) => (
                         <div key={id} className="flex items-center gap-2">
                           <span className="text-sm w-24 truncate">{getMemberName(id)}</span>
                           <Input
-                            type="number"
+                            type="text"
+                            inputMode="decimal"
                             min="0"
                             step="0.01"
                             value={fixedAmounts[id] ?? ''}
-                            placeholder="0.00"
+                            placeholder="0,00"
                             onChange={(e) =>
                               setFixedAmounts((prev) => ({
                                 ...prev,
@@ -704,7 +701,7 @@ export function ExpenseList({ group }: ExpenseListProps) {
                             }
                             className="w-28"
                           />
-                          <span className="text-sm text-muted-foreground">{symbol}</span>
+                          <span className="text-sm text-muted-foreground">{group.currency}</span>
                         </div>
                       ))}
                     </div>
@@ -724,7 +721,7 @@ export function ExpenseList({ group }: ExpenseListProps) {
                             <div key={id} className="flex justify-between text-sm">
                               <span>{getMemberName(id)}</span>
                               <span className="font-medium tabular-nums">
-                                {share.toFixed(2)} {symbol}
+                                {formatMoney(share, group.currency)}
                               </span>
                             </div>
                           )
@@ -732,7 +729,7 @@ export function ExpenseList({ group }: ExpenseListProps) {
                         <div className="flex justify-between text-xs text-muted-foreground border-t pt-1 mt-1">
                           <span>Total</span>
                           <span className="tabular-nums">
-                            {Object.values(previewShares).reduce((s, v) => s + v, 0).toFixed(2)} {symbol}
+                            {formatMoney(Object.values(previewShares).reduce((s, v) => s + v, 0), group.currency)}
                           </span>
                         </div>
                       </div>
@@ -885,7 +882,7 @@ export function ExpenseList({ group }: ExpenseListProps) {
                   {formatDate(date)}
                 </div>
                 <div className="text-xs font-semibold text-muted-foreground">
-                  {items.reduce((s, e) => s + e.amount, 0).toFixed(2)} {symbol}
+                  {formatMoney(items.reduce((s, e) => s + e.amount, 0), group.currency)}
                 </div>
               </div>
               <div className="space-y-2">
@@ -924,7 +921,7 @@ export function ExpenseList({ group }: ExpenseListProps) {
                         </div>
                         <div className="text-right ml-4 flex flex-col items-end gap-1">
                           <div className="font-semibold">
-                            {expense.amount.toFixed(2)} {symbol}
+                            {formatMoney(expense.amount, group.currency)}
                           </div>
                           <div className="flex items-center gap-1">
                             {expense.receiptImage && (
@@ -1055,7 +1052,7 @@ export function ExpenseList({ group }: ExpenseListProps) {
             <div className="flex items-center justify-between px-3 pt-1 text-sm font-medium text-muted-foreground">
               <span>Total ({visibleExpenses.length} despeses)</span>
               <span>
-                {visibleExpenses.reduce((s, e) => s + e.amount, 0).toFixed(2)} {symbol}
+                {formatMoney(visibleExpenses.reduce((s, e) => s + e.amount, 0), group.currency)}
               </span>
             </div>
           )}
@@ -1089,7 +1086,7 @@ export function ExpenseList({ group }: ExpenseListProps) {
             <div className="absolute left-2 top-2 max-w-[70vw] rounded-lg bg-card/95 px-3 py-2 shadow">
               <p className="text-sm font-medium">{viewingReceipt.description}</p>
               <p className="text-xs text-muted-foreground">
-                {viewingReceipt.payerName} ha pagat · {viewingReceipt.amount.toFixed(2)} {symbol}
+                {viewingReceipt.payerName} ha pagat · {formatMoney(viewingReceipt.amount, group.currency)}
               </p>
             </div>
             <button

--- a/src/features/groups/GroupList.tsx
+++ b/src/features/groups/GroupList.tsx
@@ -18,6 +18,7 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 import { getLocalDeviceIdentity, needsDeviceLabelSetup } from '@/lib/device-identity'
+import { formatMoney } from '@/lib/number-format'
 
 export function GroupList() {
   const { groups, groupTotals, loadGroups, addGroup, deleteGroup, importGroup } = useStore()
@@ -134,10 +135,7 @@ export function GroupList() {
             {total > 0 && (
               <span className="inline-flex items-baseline justify-end gap-1 whitespace-nowrap text-sm">
                 <span className="font-medium text-foreground/90">
-                  {total.toFixed(2)}
-                </span>
-                <span className="text-xs text-muted-foreground">
-                  {group.currency}
+                  {formatMoney(total, group.currency)}
                 </span>
               </span>
             )}

--- a/src/features/groups/OnboardingWizard.tsx
+++ b/src/features/groups/OnboardingWizard.tsx
@@ -13,6 +13,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { formatMoney, parseLocaleNumber } from '@/lib/number-format'
 
 type Step = 1 | 2 | 3
 
@@ -157,7 +158,7 @@ export function OnboardingWizard() {
     e.preventDefault()
     if (!draft.groupId || members.length < 2) return
 
-    const amount = parseFloat(draft.expenseAmount)
+    const amount = parseLocaleNumber(draft.expenseAmount)
     const payer = members[Number(draft.payerIndex)]
     if (!draft.expenseDescription.trim() || !payer || Number.isNaN(amount) || amount <= 0) return
 
@@ -182,7 +183,7 @@ export function OnboardingWizard() {
 
   const cleanMemberNames = draft.memberNames.map((name) => name.trim()).filter(Boolean)
   const canContinueMembers = cleanMemberNames.length >= 2
-  const canContinueExpense = !!draft.expenseDescription.trim() && Number(draft.expenseAmount) > 0 && members.length >= 2
+  const canContinueExpense = !!draft.expenseDescription.trim() && parseLocaleNumber(draft.expenseAmount) > 0 && members.length >= 2
 
   if (!isReady) {
     return <div className="max-w-2xl mx-auto p-4">Carregant…</div>
@@ -346,7 +347,8 @@ export function OnboardingWizard() {
                   <Label htmlFor="expense-amount">Import</Label>
                   <Input
                     id="expense-amount"
-                    type="number"
+                    type="text"
+                    inputMode="decimal"
                     min="0.01"
                     step="0.01"
                     value={draft.expenseAmount}
@@ -407,7 +409,7 @@ export function OnboardingWizard() {
                 </div>
                 <div className="rounded-2xl bg-muted/40 p-3">
                   <div className="text-muted-foreground">Primera despesa</div>
-                  <div className="font-medium">{draft.expenseDescription.trim() || 'Sense definir'}{draft.expenseAmount ? ` · ${draft.expenseAmount} €` : ''}</div>
+                  <div className="font-medium">{draft.expenseDescription.trim() || 'Sense definir'}{draft.expenseAmount && !Number.isNaN(parseLocaleNumber(draft.expenseAmount)) ? ` · ${formatMoney(parseLocaleNumber(draft.expenseAmount))}` : ''}</div>
                 </div>
               </div>
               <div className="rounded-2xl border border-indigo-200 bg-indigo-50 p-4 text-sm text-indigo-900 dark:border-indigo-900 dark:bg-indigo-950/50 dark:text-indigo-100">

--- a/src/features/groups/activity-utils.ts
+++ b/src/features/groups/activity-utils.ts
@@ -1,19 +1,13 @@
 import type { ActivityEntry, Group } from '@/domain'
 import { getDefaultDeviceLabel, getShortDeviceSuffix } from '@/lib/device-identity'
+import { formatMoney as formatLocalizedMoney } from '@/lib/number-format'
 
 type Snapshot = Record<string, unknown>
 type ActivityMeta = Record<string, unknown>
 
-const CURRENCY_SYMBOLS: Record<string, string> = {
-  EUR: '€',
-  USD: '$',
-  GBP: '£',
-}
-
 function formatMoney(value: unknown, currency = 'EUR'): string | null {
   if (typeof value !== 'number') return null
-  const symbol = CURRENCY_SYMBOLS[currency] ?? currency
-  return `${value.toFixed(2)} ${symbol}`
+  return formatLocalizedMoney(value, currency)
 }
 
 function formatValue(value: unknown, currency = 'EUR'): string | null {

--- a/src/features/settlements/SettlementList.tsx
+++ b/src/features/settlements/SettlementList.tsx
@@ -25,14 +25,9 @@ import {
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog'
 import { Badge } from '@/components/ui/badge'
-import { reparteix } from '@/sdk'
 import { ItemActivityDialog } from '@/features/groups/ItemActivityDialog'
-
-const CURRENCY_SYMBOLS: Record<string, string> = {
-  EUR: '€',
-  USD: '$',
-  GBP: '£',
-}
+import { formatDecimalInput, formatMoney, parseLocaleNumber } from '@/lib/number-format'
+import { reparteix } from '@/sdk'
 
 interface SettlementListProps {
   group: Group
@@ -48,7 +43,6 @@ export function SettlementList({ group }: SettlementListProps) {
   const [activityEntries, setActivityEntries] = useState<ActivityEntry[]>([])
 
   const activeMembers = group.members.filter((m) => !m.deleted)
-  const symbol = CURRENCY_SYMBOLS[group.currency] ?? group.currency
 
   const getMemberName = (id: string) =>
     group.members.find((m) => m.id === id)?.name ?? 'Desconegut'
@@ -76,7 +70,7 @@ export function SettlementList({ group }: SettlementListProps) {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!fromId || !toId || !amount || fromId === toId) return
-    const amountNum = parseFloat(amount)
+    const amountNum = parseLocaleNumber(amount)
     if (isNaN(amountNum) || amountNum <= 0) return
 
     if (editingPaymentId) {
@@ -116,7 +110,7 @@ export function SettlementList({ group }: SettlementListProps) {
     setEditingPaymentId(payment.id)
     setFromId(payment.fromId)
     setToId(payment.toId)
-    setAmount(payment.amount.toString())
+    setAmount(formatDecimalInput(payment.amount))
     setShowForm(true)
   }
 
@@ -179,7 +173,8 @@ export function SettlementList({ group }: SettlementListProps) {
                   </div>
                   <div className="flex gap-2">
                     <Input
-                      type="number"
+                      type="text"
+                      inputMode="decimal"
                       value={amount}
                       onChange={(e) => setAmount(e.target.value)}
                       placeholder="Import"
@@ -189,7 +184,7 @@ export function SettlementList({ group }: SettlementListProps) {
                       required
                     />
                     <span className="flex items-center text-muted-foreground">
-                      {symbol}
+                      {group.currency}
                     </span>
                   </div>
                   <div className="flex gap-2">
@@ -253,7 +248,7 @@ export function SettlementList({ group }: SettlementListProps) {
                   </div>
                   <div className="flex items-center gap-3 ml-4">
                     <span className="font-semibold text-emerald-600 dark:text-emerald-400">
-                      {payment.amount.toFixed(2)} {symbol}
+                      {formatMoney(payment.amount, group.currency)}
                     </span>
                     {!group.archived && (
                       <Button

--- a/src/lib/number-format.test.ts
+++ b/src/lib/number-format.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatDecimalInput, formatMoney, formatPercent, parseLocaleNumber } from './number-format'
+
+describe('number-format', () => {
+  it('formats money with ca-ES locale by default', () => {
+    expect(formatMoney(12.5, 'EUR')).toBe('12,50 €')
+  })
+
+  it('formats percentages with locale decimals', () => {
+    expect(formatPercent(0.125, 1)).toBe('12,5 %')
+  })
+
+  it('parses localized decimal inputs', () => {
+    expect(parseLocaleNumber('12,5')).toBe(12.5)
+    expect(parseLocaleNumber(' 1 234,56 € ')).toBe(1234.56)
+  })
+
+  it('formats numbers back for decimal inputs', () => {
+    expect(formatDecimalInput(12.5)).toBe('12,5')
+  })
+})

--- a/src/lib/number-format.ts
+++ b/src/lib/number-format.ts
@@ -1,0 +1,64 @@
+const DEFAULT_LOCALE = 'ca-ES'
+
+function getSafeLocale(locale?: string): string {
+  return locale?.trim() || DEFAULT_LOCALE
+}
+
+export function formatNumber(
+  value: number,
+  options?: Intl.NumberFormatOptions,
+  locale?: string,
+): string {
+  return new Intl.NumberFormat(getSafeLocale(locale), options).format(value)
+}
+
+export function formatMoney(value: number, currency = 'EUR', locale?: string): string {
+  try {
+    return formatNumber(
+      value,
+      {
+        style: 'currency',
+        currency,
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      },
+      locale,
+    )
+  } catch {
+    return `${formatNumber(value, { minimumFractionDigits: 2, maximumFractionDigits: 2 }, locale)} ${currency}`
+  }
+}
+
+export function formatPercent(value: number, maximumFractionDigits = 1, locale?: string): string {
+  return formatNumber(
+    value,
+    {
+      style: 'percent',
+      minimumFractionDigits: 0,
+      maximumFractionDigits,
+    },
+    locale,
+  )
+}
+
+export function parseLocaleNumber(value: string): number {
+  const trimmed = value
+    .trim()
+    .replace(/\s+/g, '')
+    .replace(/€/g, '')
+
+  if (!trimmed) return Number.NaN
+
+  const normalized = trimmed.includes(',') && trimmed.includes('.')
+    ? trimmed.replace(/\./g, '').replace(/,/g, '.')
+    : trimmed.includes(',')
+      ? trimmed.replace(/,/g, '.')
+      : trimmed
+
+  return Number(normalized)
+}
+
+export function formatDecimalInput(value: number): string {
+  if (!Number.isFinite(value)) return ''
+  return String(value).replace('.', ',')
+}


### PR DESCRIPTION
## Resum
- afegeixo una utilitat central per formatar imports, percentatges i parsejar decimals localitzats
- substitueixo formats manuals a balanços, despeses, pagaments, activitat, onboarding i llistat de grups
- permeto entrada amb coma decimal als formularis clau

## Validació
- npm test
- npm run typecheck
- npm run build

Closes #176
