### PR TITLE
Arreglar sincronització repetida: timeout, estat i progrés

### DIFF
--- a/src/features/groups/SyncFromUrl.tsx
+++ b/src/features/groups/SyncFromUrl.tsx
@@ -81,6 +81,10 @@ export function SyncFromUrl() {
     groupId,
     passphrase,
   })
+  const transferProgressPercent = sync.transferTotalChunks > 0
+    ? Math.max(0, Math.min(100, (sync.transferCompletedChunks / sync.transferTotalChunks) * 100))
+    : 0
+  const showTransferProgress = sync.transferDirection !== null && sync.transferTotalChunks > 0
 
   useEffect(() => {
     if (passphrase) {
@@ -238,6 +242,21 @@ export function SyncFromUrl() {
             <p className="text-sm font-medium leading-snug">
               {sync.message || 'Connectant amb l\'altre dispositiu…'}
             </p>
+
+            {showTransferProgress && (
+              <div className="space-y-1.5">
+                <div className="h-2 overflow-hidden rounded-full bg-muted">
+                  <div
+                    className="h-full rounded-full bg-primary transition-[width] duration-200 ease-out"
+                    style={{ width: `${transferProgressPercent}%` }}
+                  />
+                </div>
+                <div className="flex items-center justify-between text-xs text-muted-foreground">
+                  <span>{sync.transferDirection === 'sending' ? 'Enviant dades' : 'Rebent dades'}</span>
+                  <span>{Math.round(transferProgressPercent)}%</span>
+                </div>
+              </div>
+            )}
 
             {/* Error details */}
             {sync.state === 'error' && sync.error && (

--- a/src/features/groups/SyncPanel.tsx
+++ b/src/features/groups/SyncPanel.tsx
@@ -396,6 +396,10 @@ export function SyncPanel({ groupId, embedded = false, onActiveStateChange }: Sy
   const isEmbeddedWaiting = embedded && isWaitingForPeer
   const hideSetupWhileWaiting = isWaitingForPeer
   const syncUrl = canStart ? buildSyncUrl(groupId, passphrase) : ''
+  const transferProgressPercent = sync.transferTotalChunks > 0
+    ? Math.max(0, Math.min(100, (sync.transferCompletedChunks / sync.transferTotalChunks) * 100))
+    : 0
+  const showTransferProgress = sync.transferDirection !== null && sync.transferTotalChunks > 0
   const [qrMarkup, setQrMarkup] = useState('')
 
   useEffect(() => {
@@ -594,6 +598,20 @@ export function SyncPanel({ groupId, embedded = false, onActiveStateChange }: Sy
             {/* Status message */}
             <div className="space-y-3">
               {!isWaitingForPeer && <p className="text-sm font-medium leading-snug">{sync.message}</p>}
+              {!isWaitingForPeer && showTransferProgress && (
+                <div className="space-y-1.5">
+                  <div className="h-2 overflow-hidden rounded-full bg-muted">
+                    <div
+                      className="h-full rounded-full bg-primary transition-[width] duration-200 ease-out"
+                      style={{ width: `${transferProgressPercent}%` }}
+                    />
+                  </div>
+                  <div className="flex items-center justify-between text-xs text-muted-foreground">
+                    <span>{sync.transferDirection === 'sending' ? 'Enviant dades' : 'Rebent dades'}</span>
+                    <span>{Math.round(transferProgressPercent)}%</span>
+                  </div>
+                </div>
+              )}
               {!isWaitingForPeer && <SyncStepList state={sync.state} compact={embedded} />}
               {sync.error && (
                 <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">

--- a/src/hooks/useSync.ts
+++ b/src/hooks/useSync.ts
@@ -23,6 +23,9 @@ export interface UseSyncReturn {
   remotePeerIds: string[]
   /** Human-readable status message */
   message: string
+  transferDirection: 'sending' | 'receiving' | null
+  transferCompletedChunks: number
+  transferTotalChunks: number
   /** Error message if state is 'error' */
   error: string | null
   /** Sync report with details of what changed */
@@ -62,6 +65,9 @@ export function useSync({
     lastAttemptAt: null,
     lastSuccessAt: null,
     message: '',
+    transferDirection: null,
+    transferCompletedChunks: 0,
+    transferTotalChunks: 0,
   })
 
   const sessionRef = useRef<ReturnType<typeof createSyncSession> | null>(null)
@@ -133,6 +139,9 @@ export function useSync({
       lastAttemptAt: null,
       lastSuccessAt: null,
       message: '',
+      transferDirection: null,
+      transferCompletedChunks: 0,
+      transferTotalChunks: 0,
     })
   }, [groupId, passphrase])
 
@@ -183,6 +192,9 @@ export function useSync({
     remotePeerId: status.remotePeerId,
     remotePeerIds: status.remotePeerIds,
     message: status.message,
+    transferDirection: status.transferDirection,
+    transferCompletedChunks: status.transferCompletedChunks,
+    transferTotalChunks: status.transferTotalChunks,
     error: status.error,
     report: status.report,
     lastAttemptAt: status.lastAttemptAt,

--- a/src/infra/sync/peer-manager.ts
+++ b/src/infra/sync/peer-manager.ts
@@ -173,6 +173,19 @@ export function createPeerManager(options: PeerManagerOptions) {
      * Resolves with the assigned peer ID.
      */
     async init(customPeerId?: string): Promise<string> {
+      if (pendingConnectReject) {
+        pendingConnectReject(new Error('La connexió anterior s\'ha reinicialitzat'))
+        pendingConnectReject = null
+      }
+
+      for (const conn of connections.values()) {
+        conn.close()
+      }
+      connections.clear()
+      peer?.destroy()
+      peer = null
+      localPeerId = null
+
       setState('connecting')
 
       // Dynamic import — PeerJS is a browser-only dependency

--- a/src/infra/sync/sync-session.ts
+++ b/src/infra/sync/sync-session.ts
@@ -544,9 +544,10 @@ export function createSyncSession(
         }
 
         if (remotePeerId && maybeCompleteSync(remotePeerId)) {
-        } else {
-          update({ message: 'El peer no té dades per aquest grup.' })
+          return
         }
+
+        update({ message: 'El peer no té dades per aquest grup.' })
       }
     } else if (message.status === 'error') {
       update({

--- a/src/infra/sync/sync-session.ts
+++ b/src/infra/sync/sync-session.ts
@@ -710,6 +710,8 @@ export function createSyncSession(
           update({ state: 'error', error: friendly, message: `Error: ${friendly}` })
           throw err
         }
+
+        peerManager.destroy()
       }
 
       try {

--- a/src/infra/sync/sync-session.ts
+++ b/src/infra/sync/sync-session.ts
@@ -55,6 +55,9 @@ export interface SyncSessionStatus {
   lastSuccessAt: string | null
   /** Human-readable progress message */
   message: string
+  transferDirection: 'sending' | 'receiving' | null
+  transferCompletedChunks: number
+  transferTotalChunks: number
 }
 
 export type SyncSessionListener = (status: SyncSessionStatus) => void
@@ -80,6 +83,9 @@ export function createSyncSession(
     lastAttemptAt: null,
     lastSuccessAt: null,
     message: 'Inicialitzant…',
+    transferDirection: null,
+    transferCompletedChunks: 0,
+    transferTotalChunks: 0,
   }
 
   function update(patch: Partial<SyncSessionStatus>) {
@@ -132,6 +138,7 @@ export function createSyncSession(
     localDataApplied: boolean
     remoteAppliedLocalData: boolean
     remoteHadNoData: boolean
+    localHadNoData: boolean
   }>()
   const incomingPayloadChunks = new Map<string, {
     remotePeerId: string
@@ -170,17 +177,55 @@ export function createSyncSession(
       localDataApplied: false,
       remoteAppliedLocalData: false,
       remoteHadNoData: false,
+      localHadNoData: false,
     }
     peerSyncState.set(remotePeerId, created)
     return created
+  }
+
+  function resetTransferProgress() {
+    update({
+      transferDirection: null,
+      transferCompletedChunks: 0,
+      transferTotalChunks: 0,
+    })
+  }
+
+  function updateTransferProgress(direction: 'sending' | 'receiving', completedChunks: number, totalChunks: number) {
+    update({
+      transferDirection: direction,
+      transferCompletedChunks: completedChunks,
+      transferTotalChunks: totalChunks,
+    })
+  }
+
+  function maybeCompleteSync(remotePeerId: string): boolean {
+    const syncState = getPeerSyncState(remotePeerId)
+
+    const inboundSideDone = syncState.localDataApplied || syncState.remoteHadNoData
+    const outboundSideDone = syncState.remoteAppliedLocalData || syncState.localHadNoData
+
+    if (!inboundSideDone || !outboundSideDone) return false
+
+    resetTransferProgress()
+    update({
+      state: 'completed',
+      lastSuccessAt: new Date().toISOString(),
+      message: syncState.localDataApplied
+        ? 'Sincronització completada. Els dos dispositius ja estan al dia.'
+        : 'Sincronització completada. No hi havia canvis pendents per intercanviar.',
+    })
+    return true
   }
 
   async function sendEncryptedPayload(conn: PeerConnection, targetGroupId: string, payload: EncryptedPayload) {
     const syncDataMessage = createSyncDataMessage(targetGroupId, payload)
 
     if (getEncodedMessageLength(syncDataMessage) <= MAX_SYNC_CHUNK_SIZE) {
+      updateTransferProgress('sending', 1, 1)
       update({ message: 'Enviant dades…' })
       conn.send(syncDataMessage)
+      resetTransferProgress()
       update({ message: 'Dades enviades. Esperant aplicació…' })
       return
     }
@@ -225,10 +270,12 @@ export function createSyncSession(
     const total = chunks.length
     outgoingTransferInFlight = true
     for (const [index, chunk] of chunks.entries()) {
-      update({ message: `Enviant dades grans… (${index + 1}/${total})` })
+      updateTransferProgress('sending', index + 1, total)
+      update({ message: 'Enviant dades grans…' })
       conn.send(createSyncDataChunkMessage(targetGroupId, transferId, index, total, chunk))
     }
     outgoingTransferInFlight = false
+    resetTransferProgress()
     update({ message: 'Dades enviades. Esperant aplicació…' })
   }
 
@@ -277,12 +324,14 @@ export function createSyncSession(
     const receivedCount = transfer.chunks.filter((value) => value.length > 0).length
     const isComplete = receivedCount === total
     if (!isComplete) {
-      update({ message: `Rebent dades grans… (${receivedCount}/${total})` })
+      updateTransferProgress('receiving', receivedCount, total)
+      update({ message: 'Rebent dades grans…' })
       return
     }
 
     incomingPayloadChunks.delete(transferKey)
     incomingTransferInFlight = false
+    updateTransferProgress('receiving', total, total)
 
     let payload: EncryptedPayload
     try {
@@ -396,6 +445,7 @@ export function createSyncSession(
 
     try {
       if (hadLocalGroupAtSessionStart === false) {
+        getPeerSyncState(remotePeerId).localHadNoData = true
         conn.send(createSyncAckMessage(groupId, 'no-data'))
         return
       }
@@ -403,6 +453,7 @@ export function createSyncSession(
       // Build envelope from local data
       const envelope = await buildEnvelope()
       if (!envelope) {
+        getPeerSyncState(remotePeerId).localHadNoData = true
         conn.send(createSyncAckMessage(groupId, 'no-data'))
         return
       }
@@ -442,11 +493,17 @@ export function createSyncSession(
       conn?.send(createSyncAckMessage(groupId, 'ok'))
       getPeerSyncState(remotePeerId).localDataApplied = true
 
+      resetTransferProgress()
+
+      if (maybeCompleteSync(remotePeerId)) {
+        update({ report, message: buildReportSummary(report) })
+        return
+      }
+
       update({
-        state: 'completed',
+        state: 'syncing',
         report,
-        lastSuccessAt: new Date().toISOString(),
-        message: buildReportSummary(report),
+        message: 'Canvis rebuts i aplicats. Esperant confirmació final de l’altre dispositiu…',
       })
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Error aplicant dades'
@@ -472,14 +529,7 @@ export function createSyncSession(
           syncState.remoteAppliedLocalData = true
         }
 
-        if (syncState?.localDataApplied || syncState?.remoteHadNoData) {
-          update({
-            state: 'completed',
-            lastSuccessAt: new Date().toISOString(),
-            message: syncState?.localDataApplied
-              ? 'Sincronització completada. Els dos dispositius ja estan al dia.'
-              : 'Sincronització completada. L’altre dispositiu ha aplicat les dades i no tenia canvis addicionals per enviar.',
-          })
+        if (remotePeerId && maybeCompleteSync(remotePeerId)) {
           return
         }
 
@@ -493,12 +543,7 @@ export function createSyncSession(
           syncState.remoteHadNoData = true
         }
 
-        if (syncState?.localDataApplied || syncState?.localDataSent || syncState?.remoteAppliedLocalData) {
-          update({
-            state: 'completed',
-            lastSuccessAt: new Date().toISOString(),
-            message: 'Sincronització completada. L’altre dispositiu no tenia canvis addicionals per enviar.',
-          })
+        if (remotePeerId && maybeCompleteSync(remotePeerId)) {
         } else {
           update({ message: 'El peer no té dades per aquest grup.' })
         }
@@ -537,9 +582,9 @@ export function createSyncSession(
       outgoingTransferInFlight = false
       incomingTransferInFlight = false
 
-      const canTreatAsCompleted = !wasTransferring && (
-        syncState?.localDataApplied ||
-        syncState?.remoteAppliedLocalData
+      const canTreatAsCompleted = !wasTransferring && !!syncState && (
+        (syncState.localDataApplied || syncState.remoteHadNoData) &&
+        (syncState.remoteAppliedLocalData || syncState.localHadNoData)
       )
 
       if (canTreatAsCompleted) {


### PR DESCRIPTION
## Resum
- netejo completament l'estat de PeerJS abans de cada `init()`
- destrueixo explícitament el peer fallit abans del fallback host→guest a `startSync()`
- evito reutilitzar estat residual entre intents de sincronització consecutius
- evito marcar la sync com a completada abans que les dues bandes hagin tancat l'intercanvi
- afegeixo estat explícit de progrés de transferència a la sessió de sync
- mostro una progress bar tant al panell principal com al flux d'entrada per enllaç/QR

## Validació
- npm run typecheck
- npm test
- npm run build

Closes #180
