### PR TITLE
feat: add group executive summary

### DIFF
--- a/src/domain/services/index.ts
+++ b/src/domain/services/index.ts
@@ -24,6 +24,12 @@ export {
 export { getMemberColor } from './colors'
 
 export {
+  calculateGroupExecutiveSummary,
+  type GroupExecutiveSummary,
+  type GroupSummaryLeader,
+} from './reporting'
+
+export {
   generateSalt,
   deriveGroupKey,
   encryptPayload,

--- a/src/domain/services/reporting.test.ts
+++ b/src/domain/services/reporting.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import { calculateGroupExecutiveSummary } from './reporting'
+import type { Expense, Payment } from '../entities'
+
+const members = ['anna', 'bert', 'clara']
+
+const expenses: Expense[] = [
+  {
+    id: 'e1',
+    groupId: 'g1',
+    description: 'Sopar',
+    amount: 60,
+    payerId: 'anna',
+    splitAmong: members,
+    date: '2026-04-10',
+    createdAt: '2026-04-10T10:00:00.000Z',
+    updatedAt: '2026-04-10T10:00:00.000Z',
+    deleted: false,
+    archived: false,
+  },
+  {
+    id: 'e2',
+    groupId: 'g1',
+    description: 'Taxi',
+    amount: 30,
+    payerId: 'bert',
+    splitAmong: ['anna', 'bert'],
+    date: '2026-04-11',
+    createdAt: '2026-04-11T10:00:00.000Z',
+    updatedAt: '2026-04-11T10:00:00.000Z',
+    deleted: false,
+    archived: false,
+  },
+  {
+    id: 'e3',
+    groupId: 'g1',
+    description: 'Deleted expense',
+    amount: 999,
+    payerId: 'clara',
+    splitAmong: ['clara'],
+    date: '2026-04-12',
+    createdAt: '2026-04-12T10:00:00.000Z',
+    updatedAt: '2026-04-12T10:00:00.000Z',
+    deleted: true,
+    archived: false,
+  },
+]
+
+const payments: Payment[] = [
+  {
+    id: 'p1',
+    groupId: 'g1',
+    fromId: 'clara',
+    toId: 'anna',
+    amount: 20,
+    date: '2026-04-12',
+    createdAt: '2026-04-12T10:00:00.000Z',
+    updatedAt: '2026-04-12T10:00:00.000Z',
+    deleted: false,
+  },
+  {
+    id: 'p2',
+    groupId: 'g1',
+    fromId: 'anna',
+    toId: 'bert',
+    amount: 5,
+    date: '2026-04-13',
+    createdAt: '2026-04-13T10:00:00.000Z',
+    updatedAt: '2026-04-13T10:00:00.000Z',
+    deleted: true,
+  },
+]
+
+describe('calculateGroupExecutiveSummary', () => {
+  it('builds the executive summary from active expenses and payments', () => {
+    const summary = calculateGroupExecutiveSummary(members, expenses, payments)
+
+    expect(summary).toMatchObject({
+      totalExpenses: 90,
+      expenseCount: 2,
+      paymentCount: 1,
+      averageExpense: 45,
+      firstExpenseDate: '2026-04-10',
+      lastExpenseDate: '2026-04-11',
+      outstandingBalanceTotal: 5,
+      topPayerByAmount: {
+        memberId: 'anna',
+        value: 60,
+      },
+      topPayerByCount: {
+        memberId: 'anna',
+        value: 1,
+      },
+    })
+  })
+
+  it('returns a safe empty summary with no data', () => {
+    const summary = calculateGroupExecutiveSummary([], [], [])
+
+    expect(summary).toEqual({
+      totalExpenses: 0,
+      expenseCount: 0,
+      paymentCount: 0,
+      averageExpense: 0,
+      firstExpenseDate: null,
+      lastExpenseDate: null,
+      outstandingBalanceTotal: 0,
+      topPayerByAmount: null,
+      topPayerByCount: null,
+    })
+  })
+})

--- a/src/domain/services/reporting.test.ts
+++ b/src/domain/services/reporting.test.ts
@@ -44,6 +44,19 @@ const expenses: Expense[] = [
     deleted: true,
     archived: false,
   },
+  {
+    id: 'e4',
+    groupId: 'g2',
+    description: 'Altre grup',
+    amount: 500,
+    payerId: 'clara',
+    splitAmong: ['clara'],
+    date: '2026-04-14',
+    createdAt: '2026-04-14T10:00:00.000Z',
+    updatedAt: '2026-04-14T10:00:00.000Z',
+    deleted: false,
+    archived: false,
+  },
 ]
 
 const payments: Payment[] = [
@@ -69,11 +82,22 @@ const payments: Payment[] = [
     updatedAt: '2026-04-13T10:00:00.000Z',
     deleted: true,
   },
+  {
+    id: 'p3',
+    groupId: 'g2',
+    fromId: 'clara',
+    toId: 'anna',
+    amount: 999,
+    date: '2026-04-14',
+    createdAt: '2026-04-14T10:00:00.000Z',
+    updatedAt: '2026-04-14T10:00:00.000Z',
+    deleted: false,
+  },
 ]
 
 describe('calculateGroupExecutiveSummary', () => {
   it('builds the executive summary from active expenses and payments', () => {
-    const summary = calculateGroupExecutiveSummary(members, expenses, payments)
+    const summary = calculateGroupExecutiveSummary('g1', members, expenses, payments)
 
     expect(summary).toMatchObject({
       totalExpenses: 90,
@@ -95,7 +119,7 @@ describe('calculateGroupExecutiveSummary', () => {
   })
 
   it('returns a safe empty summary with no data', () => {
-    const summary = calculateGroupExecutiveSummary([], [], [])
+    const summary = calculateGroupExecutiveSummary('g1', [], [], [])
 
     expect(summary).toEqual({
       totalExpenses: 0,

--- a/src/domain/services/reporting.ts
+++ b/src/domain/services/reporting.ts
@@ -1,0 +1,90 @@
+import type { Expense, Payment } from '../entities'
+import { calculateBalances } from './balances'
+
+export interface GroupSummaryLeader {
+  memberId: string
+  value: number
+}
+
+export interface GroupExecutiveSummary {
+  totalExpenses: number
+  expenseCount: number
+  paymentCount: number
+  averageExpense: number
+  firstExpenseDate: string | null
+  lastExpenseDate: string | null
+  outstandingBalanceTotal: number
+  topPayerByAmount: GroupSummaryLeader | null
+  topPayerByCount: GroupSummaryLeader | null
+}
+
+function roundMoney(value: number): number {
+  return Math.round(value * 100) / 100
+}
+
+export function calculateGroupExecutiveSummary(
+  memberIds: string[],
+  expenses: Expense[],
+  payments: Payment[],
+): GroupExecutiveSummary {
+  const activeExpenses = expenses.filter((expense) => !expense.deleted)
+  const activePayments = payments.filter((payment) => !payment.deleted)
+
+  const totalExpenses = roundMoney(
+    activeExpenses.reduce((sum, expense) => sum + expense.amount, 0),
+  )
+
+  const averageExpense = activeExpenses.length > 0
+    ? roundMoney(totalExpenses / activeExpenses.length)
+    : 0
+
+  const sortedExpenseDates = activeExpenses
+    .map((expense) => expense.date)
+    .filter(Boolean)
+    .sort((left, right) => left.localeCompare(right))
+
+  const balances = calculateBalances(memberIds, activeExpenses, activePayments)
+  const outstandingBalanceTotal = roundMoney(
+    balances
+      .filter((balance) => balance.total > 0.01)
+      .reduce((sum, balance) => sum + balance.total, 0),
+  )
+
+  const paidAmountByMember = new Map<string, number>()
+  const paidCountByMember = new Map<string, number>()
+
+  for (const expense of activeExpenses) {
+    paidAmountByMember.set(
+      expense.payerId,
+      roundMoney((paidAmountByMember.get(expense.payerId) ?? 0) + expense.amount),
+    )
+    paidCountByMember.set(expense.payerId, (paidCountByMember.get(expense.payerId) ?? 0) + 1)
+  }
+
+  const topPayerByAmount = getTopLeader(paidAmountByMember)
+  const topPayerByCount = getTopLeader(paidCountByMember)
+
+  return {
+    totalExpenses,
+    expenseCount: activeExpenses.length,
+    paymentCount: activePayments.length,
+    averageExpense,
+    firstExpenseDate: sortedExpenseDates[0] ?? null,
+    lastExpenseDate: sortedExpenseDates.at(-1) ?? null,
+    outstandingBalanceTotal,
+    topPayerByAmount,
+    topPayerByCount,
+  }
+}
+
+function getTopLeader(values: Map<string, number>): GroupSummaryLeader | null {
+  let leader: GroupSummaryLeader | null = null
+
+  for (const [memberId, value] of values.entries()) {
+    if (!leader || value > leader.value) {
+      leader = { memberId, value }
+    }
+  }
+
+  return leader
+}

--- a/src/domain/services/reporting.ts
+++ b/src/domain/services/reporting.ts
@@ -23,12 +23,17 @@ function roundMoney(value: number): number {
 }
 
 export function calculateGroupExecutiveSummary(
+  groupId: string,
   memberIds: string[],
   expenses: Expense[],
   payments: Payment[],
 ): GroupExecutiveSummary {
-  const activeExpenses = expenses.filter((expense) => !expense.deleted)
-  const activePayments = payments.filter((payment) => !payment.deleted)
+  const activeExpenses = expenses.filter(
+    (expense) => expense.groupId === groupId && !expense.deleted,
+  )
+  const activePayments = payments.filter(
+    (payment) => payment.groupId === groupId && !payment.deleted,
+  )
 
   const totalExpenses = roundMoney(
     activeExpenses.reduce((sum, expense) => sum + expense.amount, 0),

--- a/src/features/groups/GroupDetail.tsx
+++ b/src/features/groups/GroupDetail.tsx
@@ -9,6 +9,7 @@ import { useStore } from '../../store'
 import { ExpenseList } from '../expenses/ExpenseList'
 import { BalanceView } from '../balances/BalanceView'
 import { SettlementList } from '../settlements/SettlementList'
+import { GroupExecutiveSummary } from './GroupExecutiveSummary'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -301,8 +302,11 @@ export function GroupDetail() {
       </div>
 
       {/* Tabs */}
-      <Tabs defaultValue="expenses" className="flex-1 flex flex-col min-h-0">
+      <Tabs defaultValue="summary" className="flex-1 flex flex-col min-h-0">
         <TabsList className="w-full shrink-0">
+          <TabsTrigger value="summary" className="flex-1">
+            Resum
+          </TabsTrigger>
           <TabsTrigger value="expenses" className="flex-1">
             Despeses
           </TabsTrigger>
@@ -314,6 +318,9 @@ export function GroupDetail() {
           </TabsTrigger>
         </TabsList>
 
+        <TabsContent value="summary" className="flex-1 overflow-y-auto min-h-0 pb-4">
+          <GroupExecutiveSummary group={group} />
+        </TabsContent>
         <TabsContent value="expenses" className="flex-1 overflow-y-auto min-h-0 pb-4">
           <ExpenseList group={group} />
         </TabsContent>

--- a/src/features/groups/GroupExecutiveSummary.tsx
+++ b/src/features/groups/GroupExecutiveSummary.tsx
@@ -1,0 +1,177 @@
+import { ReceiptText, CreditCard, Wallet, CalendarRange, Trophy, Activity } from 'lucide-react'
+import type { Group } from '@/domain/entities'
+import { calculateGroupExecutiveSummary } from '@/domain/services'
+import { formatMoney } from '@/lib/number-format'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { useStore } from '@/store'
+
+interface GroupExecutiveSummaryProps {
+  group: Group
+}
+
+const dateFormatter = new Intl.DateTimeFormat('ca-ES', {
+  day: 'numeric',
+  month: 'short',
+  year: 'numeric',
+})
+
+function formatDateRange(start: string | null, end: string | null): string {
+  if (!start || !end) return 'Encara no hi ha despeses'
+
+  const startDate = new Date(start)
+  const endDate = new Date(end)
+
+  return `${dateFormatter.format(startDate)} → ${dateFormatter.format(endDate)}`
+}
+
+export function GroupExecutiveSummary({ group }: GroupExecutiveSummaryProps) {
+  const { expenses, payments } = useStore()
+  const activeMembers = group.members.filter((member) => !member.deleted)
+  const memberById = new Map(activeMembers.map((member) => [member.id, member]))
+
+  const summary = calculateGroupExecutiveSummary(
+    activeMembers.map((member) => member.id),
+    expenses,
+    payments,
+  )
+
+  if (summary.expenseCount === 0 && summary.paymentCount === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Resum del grup</CardTitle>
+          <CardDescription>
+            Quan comenceu a registrar despeses i pagaments, aquí hi veuràs el resum executiu del grup.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    )
+  }
+
+  const topPayerByAmount = summary.topPayerByAmount
+    ? memberById.get(summary.topPayerByAmount.memberId)
+    : null
+
+  const topPayerByCount = summary.topPayerByCount
+    ? memberById.get(summary.topPayerByCount.memberId)
+    : null
+
+  const kpis = [
+    {
+      label: 'Total gastat',
+      value: formatMoney(summary.totalExpenses, group.currency),
+      icon: ReceiptText,
+    },
+    {
+      label: 'Despeses',
+      value: String(summary.expenseCount),
+      icon: Activity,
+    },
+    {
+      label: 'Pagaments',
+      value: String(summary.paymentCount),
+      icon: CreditCard,
+    },
+    {
+      label: 'Mitjana per despesa',
+      value: formatMoney(summary.averageExpense, group.currency),
+      icon: Wallet,
+    },
+    {
+      label: 'Saldo pendent',
+      value: formatMoney(summary.outstandingBalanceTotal, group.currency),
+      icon: Wallet,
+    },
+    {
+      label: 'Període actiu',
+      value: formatDateRange(summary.firstExpenseDate, summary.lastExpenseDate),
+      icon: CalendarRange,
+    },
+  ]
+
+  return (
+    <div className="space-y-4 pb-4">
+      <Card className="border-indigo-100 dark:border-indigo-900 bg-indigo-50 dark:bg-indigo-950">
+        <CardHeader>
+          <CardTitle>Resum executiu</CardTitle>
+          <CardDescription>
+            Una lectura ràpida del que ha passat al grup fins ara.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-3 sm:grid-cols-2">
+          {kpis.map(({ label, value, icon: Icon }) => (
+            <div key={label} className="rounded-xl bg-background/80 px-4 py-3 shadow-sm">
+              <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
+                <Icon className="h-3.5 w-3.5" />
+                {label}
+              </div>
+              <p className="mt-2 text-lg font-semibold text-foreground">{value}</p>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <Trophy className="h-4 w-4" />
+              Qui ha avançat més
+            </CardTitle>
+            <CardDescription>
+              Membre que més import ha pagat en despeses del grup.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {topPayerByAmount && summary.topPayerByAmount ? (
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex items-center gap-2">
+                  <span
+                    className="h-3 w-3 rounded-full"
+                    style={{ backgroundColor: topPayerByAmount.color }}
+                  />
+                  <span className="font-medium">{topPayerByAmount.name}</span>
+                </div>
+                <span className="font-semibold">
+                  {formatMoney(summary.topPayerByAmount.value, group.currency)}
+                </span>
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">Encara no hi ha prou dades.</p>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <Trophy className="h-4 w-4" />
+              Qui ha pagat més cops
+            </CardTitle>
+            <CardDescription>
+              Membre amb més despeses registrades com a pagador.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {topPayerByCount && summary.topPayerByCount ? (
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex items-center gap-2">
+                  <span
+                    className="h-3 w-3 rounded-full"
+                    style={{ backgroundColor: topPayerByCount.color }}
+                  />
+                  <span className="font-medium">{topPayerByCount.name}</span>
+                </div>
+                <span className="font-semibold">
+                  {summary.topPayerByCount.value} despesa{summary.topPayerByCount.value === 1 ? '' : 'es'}
+                </span>
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">Encara no hi ha prou dades.</p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/src/features/groups/GroupExecutiveSummary.tsx
+++ b/src/features/groups/GroupExecutiveSummary.tsx
@@ -1,4 +1,4 @@
-import { ReceiptText, CreditCard, Wallet, CalendarRange, Trophy, Activity } from 'lucide-react'
+import { CalendarRange, CreditCard, ReceiptText, Wallet } from 'lucide-react'
 import type { Group } from '@/domain/entities'
 import { calculateGroupExecutiveSummary } from '@/domain/services'
 import { formatMoney } from '@/lib/number-format'
@@ -15,13 +15,18 @@ const dateFormatter = new Intl.DateTimeFormat('ca-ES', {
   year: 'numeric',
 })
 
+function formatDate(date: string): string {
+  return dateFormatter.format(new Date(date))
+}
+
 function formatDateRange(start: string | null, end: string | null): string {
-  if (!start || !end) return 'Encara no hi ha despeses'
+  if (!start || !end) return 'Sense període encara'
+  if (start === end) return formatDate(start)
+  return `${formatDate(start)} – ${formatDate(end)}`
+}
 
-  const startDate = new Date(start)
-  const endDate = new Date(end)
-
-  return `${dateFormatter.format(startDate)} → ${dateFormatter.format(endDate)}`
+function pluralizeExpense(count: number): string {
+  return `${count} despesa${count === 1 ? '' : 'es'}`
 }
 
 export function GroupExecutiveSummary({ group }: GroupExecutiveSummaryProps) {
@@ -38,11 +43,11 @@ export function GroupExecutiveSummary({ group }: GroupExecutiveSummaryProps) {
 
   if (summary.expenseCount === 0 && summary.paymentCount === 0) {
     return (
-      <Card>
+      <Card className="border-dashed shadow-none">
         <CardHeader>
           <CardTitle>Resum del grup</CardTitle>
           <CardDescription>
-            Quan comenceu a registrar despeses i pagaments, aquí hi veuràs el resum executiu del grup.
+            Encara no hi ha prou moviment. Quan afegiu despeses, aquí sortirà una lectura ràpida del grup.
           </CardDescription>
         </CardHeader>
       </Card>
@@ -57,122 +62,83 @@ export function GroupExecutiveSummary({ group }: GroupExecutiveSummaryProps) {
     ? memberById.get(summary.topPayerByCount.memberId)
     : null
 
-  const kpis = [
+  const statusText = summary.outstandingBalanceTotal > 0.01
+    ? `Queden ${formatMoney(summary.outstandingBalanceTotal, group.currency)} per quadrar entre membres.`
+    : 'El grup està quadrat: ara mateix no hi ha saldo pendent.'
+
+  const detailRows = [
     {
-      label: 'Total gastat',
-      value: formatMoney(summary.totalExpenses, group.currency),
+      label: 'Moviment',
+      value: `${pluralizeExpense(summary.expenseCount)} · ${summary.paymentCount} pagament${summary.paymentCount === 1 ? '' : 's'}`,
       icon: ReceiptText,
     },
     {
-      label: 'Despeses',
-      value: String(summary.expenseCount),
-      icon: Activity,
-    },
-    {
-      label: 'Pagaments',
-      value: String(summary.paymentCount),
-      icon: CreditCard,
-    },
-    {
-      label: 'Mitjana per despesa',
-      value: formatMoney(summary.averageExpense, group.currency),
+      label: 'Mitjana',
+      value: `${formatMoney(summary.averageExpense, group.currency)} per despesa`,
       icon: Wallet,
     },
     {
-      label: 'Saldo pendent',
-      value: formatMoney(summary.outstandingBalanceTotal, group.currency),
-      icon: Wallet,
-    },
-    {
-      label: 'Període actiu',
+      label: 'Període',
       value: formatDateRange(summary.firstExpenseDate, summary.lastExpenseDate),
       icon: CalendarRange,
     },
   ]
 
+  const insights = [
+    topPayerByAmount && summary.topPayerByAmount
+      ? `${topPayerByAmount.name} és qui més ha avançat: ${formatMoney(summary.topPayerByAmount.value, group.currency)}.`
+      : null,
+    topPayerByCount && summary.topPayerByCount
+      ? `${topPayerByCount.name} ha registrat més despeses: ${pluralizeExpense(summary.topPayerByCount.value)}.`
+      : null,
+  ].filter(Boolean)
+
   return (
     <div className="space-y-4 pb-4">
-      <Card className="border-indigo-100 dark:border-indigo-900 bg-indigo-50 dark:bg-indigo-950">
-        <CardHeader>
-          <CardTitle>Resum executiu</CardTitle>
-          <CardDescription>
-            Una lectura ràpida del que ha passat al grup fins ara.
-          </CardDescription>
+      <Card className="overflow-hidden shadow-none">
+        <CardHeader className="space-y-3 pb-4">
+          <div className="flex items-center justify-between gap-3">
+            <CardDescription>Resum del grup</CardDescription>
+            <span className="rounded-full bg-muted px-2.5 py-1 text-xs text-muted-foreground">
+              {activeMembers.length} membre{activeMembers.length === 1 ? '' : 's'}
+            </span>
+          </div>
+          <div>
+            <CardTitle className="text-3xl leading-tight">
+              {formatMoney(summary.totalExpenses, group.currency)}
+            </CardTitle>
+            <p className="mt-2 text-sm text-muted-foreground">{statusText}</p>
+          </div>
         </CardHeader>
-        <CardContent className="grid gap-3 sm:grid-cols-2">
-          {kpis.map(({ label, value, icon: Icon }) => (
-            <div key={label} className="rounded-xl bg-background/80 px-4 py-3 shadow-sm">
-              <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
-                <Icon className="h-3.5 w-3.5" />
+
+        <CardContent className="space-y-1 pt-0">
+          {detailRows.map(({ label, value, icon: Icon }) => (
+            <div key={label} className="flex items-center justify-between gap-4 border-t py-3 first:border-t-0">
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <Icon className="h-4 w-4" />
                 {label}
               </div>
-              <p className="mt-2 text-lg font-semibold text-foreground">{value}</p>
+              <div className="text-right text-sm font-medium">{value}</div>
             </div>
           ))}
         </CardContent>
       </Card>
 
-      <div className="grid gap-4 sm:grid-cols-2">
-        <Card>
-          <CardHeader>
+      {insights.length > 0 && (
+        <Card className="bg-muted/30 shadow-none">
+          <CardHeader className="pb-3">
             <CardTitle className="flex items-center gap-2 text-base">
-              <Trophy className="h-4 w-4" />
-              Qui ha avançat més
+              <CreditCard className="h-4 w-4" />
+              Lectura ràpida
             </CardTitle>
-            <CardDescription>
-              Membre que més import ha pagat en despeses del grup.
-            </CardDescription>
           </CardHeader>
-          <CardContent>
-            {topPayerByAmount && summary.topPayerByAmount ? (
-              <div className="flex items-center justify-between gap-3">
-                <div className="flex items-center gap-2">
-                  <span
-                    className="h-3 w-3 rounded-full"
-                    style={{ backgroundColor: topPayerByAmount.color }}
-                  />
-                  <span className="font-medium">{topPayerByAmount.name}</span>
-                </div>
-                <span className="font-semibold">
-                  {formatMoney(summary.topPayerByAmount.value, group.currency)}
-                </span>
-              </div>
-            ) : (
-              <p className="text-sm text-muted-foreground">Encara no hi ha prou dades.</p>
-            )}
+          <CardContent className="space-y-2 text-sm text-muted-foreground">
+            {insights.map((insight) => (
+              <p key={insight}>• {insight}</p>
+            ))}
           </CardContent>
         </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-base">
-              <Trophy className="h-4 w-4" />
-              Qui ha pagat més cops
-            </CardTitle>
-            <CardDescription>
-              Membre amb més despeses registrades com a pagador.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            {topPayerByCount && summary.topPayerByCount ? (
-              <div className="flex items-center justify-between gap-3">
-                <div className="flex items-center gap-2">
-                  <span
-                    className="h-3 w-3 rounded-full"
-                    style={{ backgroundColor: topPayerByCount.color }}
-                  />
-                  <span className="font-medium">{topPayerByCount.name}</span>
-                </div>
-                <span className="font-semibold">
-                  {summary.topPayerByCount.value} despesa{summary.topPayerByCount.value === 1 ? '' : 'es'}
-                </span>
-              </div>
-            ) : (
-              <p className="text-sm text-muted-foreground">Encara no hi ha prou dades.</p>
-            )}
-          </CardContent>
-        </Card>
-      </div>
+      )}
     </div>
   )
 }

--- a/src/features/groups/GroupExecutiveSummary.tsx
+++ b/src/features/groups/GroupExecutiveSummary.tsx
@@ -30,6 +30,7 @@ export function GroupExecutiveSummary({ group }: GroupExecutiveSummaryProps) {
   const memberById = new Map(activeMembers.map((member) => [member.id, member]))
 
   const summary = calculateGroupExecutiveSummary(
+    group.id,
     activeMembers.map((member) => member.id),
     expenses,
     payments,

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -4,19 +4,21 @@ import {
   calculateBalances,
   calculateSettlements,
   calculateNetting,
+  calculateGroupExecutiveSummary,
   isExpenseArchivable,
   computeSyncMerge,
   getMemberColor,
   type Balance,
   type Settlement,
   type NettingResult,
+  type GroupExecutiveSummary,
   type SyncReport,
 } from './domain/services'
 import { db } from './infra/db'
 import { getLocalDeviceIdentity } from './lib/device-identity'
 
-export type { Group, Expense, Payment, Member, ActivityEntry, ActivityAction, Balance, Settlement, NettingResult, GroupExport, ReparteixExportV1, SyncEnvelopeV1, SyncReport }
-export { calculateBalances, calculateSettlements, calculateNetting }
+export type { Group, Expense, Payment, Member, ActivityEntry, ActivityAction, Balance, Settlement, NettingResult, GroupExecutiveSummary, GroupExport, ReparteixExportV1, SyncEnvelopeV1, SyncReport }
+export { calculateBalances, calculateSettlements, calculateNetting, calculateGroupExecutiveSummary }
 
 
 function generateId(): string {


### PR DESCRIPTION
## Summary
- add a first reporting MVP with an executive summary tab inside group detail
- compute reusable reporting metrics in a domain service with tests
- show key KPIs and simple leaders without adding new dependencies

## Testing
- npm test
- npm run typecheck
- npm run build

Closes #186
Related to #185
