### PR TITLE
fix: respectar dark mode al splash inicial

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,20 +11,8 @@
     <meta name="description" content="Aplicació de repartiment de despeses — local-first i 100% offline" />
     <script>
       (() => {
-        const storageKey = 'reparteix-theme'
-        const darkQuery = '(prefers-color-scheme: dark)'
-        let theme = 'system'
-
-        try {
-          const stored = localStorage.getItem(storageKey)
-          if (stored === 'light' || stored === 'dark' || stored === 'system') theme = stored
-        } catch {
-          // localStorage unavailable
-        }
-
-        const prefersDark = window.matchMedia?.(darkQuery).matches ?? false
-        const resolved = theme === 'system' ? (prefersDark ? 'dark' : 'light') : theme
-        document.documentElement.classList.toggle('dark', resolved === 'dark')
+        const prefersDark = window.matchMedia?.('(prefers-color-scheme: dark)').matches ?? false
+        document.documentElement.classList.toggle('dark', prefersDark)
       })()
     </script>
     <style>
@@ -33,13 +21,24 @@
         background: #ffffff;
       }
 
+      body {
+        background: #ffffff;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        :root {
+          color-scheme: dark;
+          background: #171717;
+        }
+
+        body {
+          background: #171717;
+        }
+      }
+
       :root.dark {
         color-scheme: dark;
         background: #171717;
-      }
-
-      body {
-        background: #ffffff;
       }
 
       :root.dark body {

--- a/index.html
+++ b/index.html
@@ -5,8 +5,47 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="theme-color" content="#863bff" />
+    <meta name="color-scheme" content="light dark" />
+    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#171717" media="(prefers-color-scheme: dark)" />
     <meta name="description" content="Aplicació de repartiment de despeses — local-first i 100% offline" />
+    <script>
+      (() => {
+        const storageKey = 'reparteix-theme'
+        const darkQuery = '(prefers-color-scheme: dark)'
+        let theme = 'system'
+
+        try {
+          const stored = localStorage.getItem(storageKey)
+          if (stored === 'light' || stored === 'dark' || stored === 'system') theme = stored
+        } catch {
+          // localStorage unavailable
+        }
+
+        const prefersDark = window.matchMedia?.(darkQuery).matches ?? false
+        const resolved = theme === 'system' ? (prefersDark ? 'dark' : 'light') : theme
+        document.documentElement.classList.toggle('dark', resolved === 'dark')
+      })()
+    </script>
+    <style>
+      :root {
+        color-scheme: light;
+        background: #ffffff;
+      }
+
+      :root.dark {
+        color-scheme: dark;
+        background: #171717;
+      }
+
+      body {
+        background: #ffffff;
+      }
+
+      :root.dark body {
+        background: #171717;
+      }
+    </style>
     <title>Reparteix</title>
   </head>
   <body>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
         name: 'Reparteix',
         short_name: 'Reparteix',
         description: 'Aplicació de repartiment de despeses — local-first i 100% offline',
-        theme_color: '#863bff',
+        theme_color: '#ffffff',
         background_color: '#ffffff',
         display: 'standalone',
         lang: 'ca',


### PR DESCRIPTION
## Resum

- Closes #193
- Afegeix `theme-color` separat per `prefers-color-scheme` light/dark.
- Aplica `.dark` en un script inline abans que carregui React, llegint primer `reparteix-theme` i caient a sistema.
- Dona fons inicial light/dark a `:root` i `body` per evitar flash clar abans del CSS/app.
- Alinea el `theme_color` del manifest amb el splash clar per no mantenir el morat fix com a color d'arrencada.

## Nota tècnica

Això cobreix el primer paint i el chrome/splash que respecta `theme-color` amb media query. Alguns launchers poden continuar usant el `background_color` estàtic del manifest perquè l'estàndard del manifest no té `background_color` per media query; per això el fallback més fiable abans de React és el script inline + CSS inicial.

## Validació

- `npm run build`
- `npm run lint` → passa amb 3 warnings existents a `coverage/lcov-report/*.js`.
