### PR TITLE
fix: highlight newly added expense

### DIFF
--- a/src/features/expenses/ExpenseList.tsx
+++ b/src/features/expenses/ExpenseList.tsx
@@ -153,10 +153,12 @@ export function ExpenseList({ group }: ExpenseListProps) {
   const [activityEntries, setActivityEntries] = useState<ActivityEntry[]>([])
   const [openExpenseMenuId, setOpenExpenseMenuId] = useState<string | null>(null)
   const [deleteExpenseId, setDeleteExpenseId] = useState<string | null>(null)
+  const [highlightedExpenseId, setHighlightedExpenseId] = useState<string | null>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const cameraInputRef = useRef<HTMLInputElement>(null)
   const modalRef = useRef<HTMLDivElement>(null)
   const receiptLoadRequestRef = useRef(0)
+  const expenseCardRefs = useRef(new Map<string, HTMLDivElement>())
 
   useEffect(() => {
     return () => {
@@ -199,6 +201,23 @@ export function ExpenseList({ group }: ExpenseListProps) {
     return () => document.removeEventListener('click', handleDocumentClick)
   }, [])
 
+  useEffect(() => {
+    if (!highlightedExpenseId) return
+
+    const frameId = window.requestAnimationFrame(() => {
+      expenseCardRefs.current.get(highlightedExpenseId)?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'center',
+      })
+    })
+    const timeoutId = window.setTimeout(() => setHighlightedExpenseId(null), 4500)
+
+    return () => {
+      window.cancelAnimationFrame(frameId)
+      window.clearTimeout(timeoutId)
+    }
+  }, [highlightedExpenseId, showArchived, visibleExpenses.length])
+
   const resetForm = () => {
     receiptLoadRequestRef.current += 1
     setEditingExpenseId(null)
@@ -213,6 +232,14 @@ export function ExpenseList({ group }: ExpenseListProps) {
     setReceiptImage(null)
     setReceiptError(null)
     setShowForm(false)
+  }
+
+  const setExpenseCardRef = (expenseId: string) => (node: HTMLDivElement | null) => {
+    if (node) {
+      expenseCardRefs.current.set(expenseId, node)
+    } else {
+      expenseCardRefs.current.delete(expenseId)
+    }
   }
 
   const buildCurrentSplitFields = () => ({
@@ -305,7 +332,9 @@ export function ExpenseList({ group }: ExpenseListProps) {
         computedShares,
       })
     } else {
-      await addExpense({ ...baseExpense, computedShares })
+      const newExpense = await addExpense({ ...baseExpense, computedShares })
+      setShowArchived(false)
+      setHighlightedExpenseId(newExpense.id)
     }
 
     resetForm()
@@ -917,11 +946,22 @@ export function ExpenseList({ group }: ExpenseListProps) {
                   const updates = expenseActivity.get(expense.id) ?? []
                   const isEdited = updates.length > 0
                   return (
-                    <Card key={expense.id} className={cn(showArchived && 'opacity-75')}>
+                    <Card
+                      key={expense.id}
+                      ref={setExpenseCardRef(expense.id)}
+                      className={cn(
+                        'scroll-mt-20 transition-colors duration-500',
+                        showArchived && 'opacity-75',
+                        highlightedExpenseId === expense.id && 'border-success bg-success/10 shadow-sm',
+                      )}
+                    >
                       <CardContent className="flex items-center justify-between p-3">
                         <div className="flex-1 space-y-1">
                           <div className="flex items-center gap-2">
                             <div className="font-medium">{expense.description}</div>
+                            {highlightedExpenseId === expense.id && (
+                              <Badge className="bg-success text-success-foreground">Afegida ara</Badge>
+                            )}
                             {isEdited && (
                               <ItemActivityDialog
                                 group={group}

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -373,11 +373,20 @@ export const reparteix = {
 
   /** List all non-deleted expenses for a group. */
   async listExpenses(groupId: string): Promise<Expense[]> {
-    return db.expenses
+    const expenses = await db.expenses
       .where('groupId')
       .equals(groupId)
       .filter((e) => !e.deleted)
       .toArray()
+
+    return expenses.sort((a, b) => {
+      const dateOrder = b.date.localeCompare(a.date)
+      if (dateOrder !== 0) return dateOrder
+
+      const aCreatedAt = a.createdAt || a.updatedAt || ''
+      const bCreatedAt = b.createdAt || b.updatedAt || ''
+      return bCreatedAt.localeCompare(aCreatedAt)
+    })
   },
 
   /** Add an expense and return it. Throws if the group is archived. */

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -21,7 +21,7 @@ interface AppState {
   addMember: (groupId: string, name: string) => Promise<void>
   removeMember: (groupId: string, memberId: string) => Promise<void>
   renameMember: (groupId: string, memberId: string, newName: string) => Promise<void>
-  addExpense: (expense: Omit<Expense, 'id' | 'createdAt' | 'updatedAt' | 'deleted' | 'archived'>) => Promise<void>
+  addExpense: (expense: Omit<Expense, 'id' | 'createdAt' | 'updatedAt' | 'deleted' | 'archived'>) => Promise<Expense>
   updateExpense: (expense: Expense) => Promise<void>
   deleteExpense: (id: string) => Promise<void>
   archiveAllSettledExpenses: (groupId: string) => Promise<number>
@@ -108,11 +108,12 @@ export const useStore = create<AppState>((set, get) => ({
   },
 
   addExpense: async (expense) => {
-    await reparteix.addExpense(expense)
+    const newExpense = await reparteix.addExpense(expense)
     await Promise.all([
       get().loadGroupData(expense.groupId),
       get().loadGroups(),
     ])
+    return newExpense
   },
 
   updateExpense: async (expense) => {

--- a/src/store/store.test.ts
+++ b/src/store/store.test.ts
@@ -252,6 +252,44 @@ describe('expenses', () => {
     expect(groupTotals[group.id]).toBe(60)
   })
 
+  it('loadGroupData ordena les despeses del mateix dia per hora de creació descendent', async () => {
+    const group = await createGroupWithMembers('Viatge', ['Anna', 'Bernat'])
+    const members = group.members
+    const baseExpense = {
+      groupId: group.id,
+      amount: 10,
+      payerId: members[0].id,
+      splitAmong: members.map((m) => m.id),
+      date: '2024-01-15',
+      archived: false,
+      deleted: false,
+    }
+
+    await db.expenses.bulkAdd([
+      {
+        ...baseExpense,
+        id: 'expense-older',
+        description: 'Primera',
+        createdAt: '2024-01-15T09:00:00.000Z',
+        updatedAt: '2024-01-15T09:00:00.000Z',
+      },
+      {
+        ...baseExpense,
+        id: 'expense-newer',
+        description: 'Segona',
+        createdAt: '2024-01-15T10:00:00.000Z',
+        updatedAt: '2024-01-15T10:00:00.000Z',
+      },
+    ])
+
+    await useStore.getState().loadGroupData(group.id)
+
+    expect(useStore.getState().expenses.map((expense) => expense.id)).toEqual([
+      'expense-newer',
+      'expense-older',
+    ])
+  })
+
   it("updateExpense actualitza les dades de la despesa a l'estat", async () => {
     const group = await createGroupWithMembers('Viatge', ['Anna', 'Bernat'])
     const members = group.members

--- a/src/store/store.test.ts
+++ b/src/store/store.test.ts
@@ -234,7 +234,7 @@ describe('expenses', () => {
     const members = group.members
 
     const { addExpense } = useStore.getState()
-    await addExpense({
+    const createdExpense = await addExpense({
       groupId: group.id,
       description: 'Sopar',
       amount: 60,
@@ -244,6 +244,7 @@ describe('expenses', () => {
     })
 
     const { expenses, groupTotals } = useStore.getState()
+    expect(createdExpense.id).toBe(expenses[0].id)
     expect(expenses).toHaveLength(1)
     expect(expenses[0].description).toBe('Sopar')
     expect(expenses[0].amount).toBe(60)


### PR DESCRIPTION
## Resum
- Fa que `addExpense` retorni la despesa creada perquè la UI pugui identificar-la sense heurístiques.
- Després de crear una despesa, torna a la vista d'actives, fa scroll fins a la targeta nova i la ressalta temporalment amb el badge "Afegida ara".
- Ordena les despeses per data descendent i, dins del mateix dia, per `createdAt` descendent perquè les noves surtin primer.
- Cobreix el nou contracte del store i l'ordre de despeses del mateix dia amb tests.

## Proves
- `npm test`
- `npm run build`
- `npm run lint` (exit 0; warnings preexistents a `coverage/lcov-report/*`)

Closes #196
